### PR TITLE
Implement workaround to json regression 

### DIFF
--- a/src/.vscode/launch.json
+++ b/src/.vscode/launch.json
@@ -12,7 +12,7 @@
             // If you have changed target frameworks, make sure to update the program path.
             // Replace osx-x64 with win-x64 if you are running in windows
             "program": "${workspaceFolder}/dsc/bin/Debug/netcoreapp3.1/osx-x64/dsc.dll",
-            "args": ["connect", "--service", "stats-api", "--local-port", "3001", "--use-kubernetes-service-environment-variables", "--namespace", "todo-app"], //, "--routing", "elvilla-8474"
+            "args": ["connect", "--service", "stats-api", "--local-port", "3001", "--use-kubernetes-service-environment-variables", "--namespace", "todo-app"],
             //"args": ["prep-connect", "--service", "stats-api"],// "--local-port", "3001", "--use-kubernetes-service-environment-variables"],
             "env": {
                 "BRIDGE_ENVIRONMENT":"dev",

--- a/src/.vscode/launch.json
+++ b/src/.vscode/launch.json
@@ -8,11 +8,11 @@
             "name": "bridge",
             "type": "coreclr",
             "request": "launch",
-            //"preLaunchTask": "BuildAndPublishMac", // Replace by BuildAndPublishWindows as needed
+            "preLaunchTask": "BuildAndPublishMac", // Replace by BuildAndPublishWindows as needed
             // If you have changed target frameworks, make sure to update the program path.
             // Replace osx-x64 with win-x64 if you are running in windows
             "program": "${workspaceFolder}/dsc/bin/Debug/netcoreapp3.1/osx-x64/dsc.dll",
-            "args": ["connect", "--service", "stats-api", "--local-port", "3001", "--use-kubernetes-service-environment-variables", "--namespace", "todo-app", "--routing", "elvilla-8474"], //,
+            "args": ["connect", "--service", "stats-api", "--local-port", "3001", "--use-kubernetes-service-environment-variables", "--namespace", "todo-app"], //, "--routing", "elvilla-8474"
             //"args": ["prep-connect", "--service", "stats-api"],// "--local-port", "3001", "--use-kubernetes-service-environment-variables"],
             "env": {
                 "BRIDGE_ENVIRONMENT":"dev",

--- a/src/.vscode/tasks.json
+++ b/src/.vscode/tasks.json
@@ -7,7 +7,7 @@
             "type": "process",
             "args": [
                 "build",
-                "${workspaceFolder}/dsc.csproj",
+                "${workspaceFolder}/dsc/dsc.csproj",
                 "/property:GenerateFullPaths=true",
                 "/consoleloggerparameters:NoSummary"
             ],
@@ -19,7 +19,7 @@
             "type": "process",
             "args": [
                 "publish",
-                "${workspaceFolder}/dsc.csproj",
+                "${workspaceFolder}/dsc/dsc.csproj",
                 "-r", "win-x64",
                 "/property:GenerateFullPaths=true",
                 "/consoleloggerparameters:NoSummary"
@@ -32,7 +32,7 @@
             "type": "process",
             "args": [
                 "publish",
-                "${workspaceFolder}/dsc.csproj",
+                "${workspaceFolder}/dsc/dsc.csproj",
                 "-r", "osx-x64",
                 "/property:GenerateFullPaths=true",
                 "/consoleloggerparameters:NoSummary"

--- a/src/library/Connect/KubernetesRemoteEnvironmentManager.cs
+++ b/src/library/Connect/KubernetesRemoteEnvironmentManager.cs
@@ -28,6 +28,7 @@ using Microsoft.BridgeToKubernetes.Library.Logging;
 using Microsoft.BridgeToKubernetes.Library.Models;
 using Microsoft.BridgeToKubernetes.Library.Utilities;
 using Microsoft.Rest;
+using Newtonsoft.Json.Serialization;
 using static k8s.Models.V1Patch;
 using static Microsoft.BridgeToKubernetes.Common.Constants;
 
@@ -723,7 +724,11 @@ namespace Microsoft.BridgeToKubernetes.Library.Connect
                 {
                     try
                     {
-                        await _kubernetesClient.PatchV1DeploymentAsync(namespaceName, deploymentName, new V1Patch(patch, PatchType.JsonPatch), cancellationToken: cancellationToken);
+                        var settings = new Newtonsoft.Json.JsonSerializerSettings 
+                        { 
+                            ContractResolver = new Newtonsoft.Json.Serialization.DefaultContractResolver { NamingStrategy = new Newtonsoft.Json.Serialization.CamelCaseNamingStrategy() }
+                        };
+                        await _kubernetesClient.PatchV1DeploymentAsync(namespaceName, deploymentName, new V1Patch(Newtonsoft.Json.JsonConvert.SerializeObject(patch, settings), PatchType.JsonPatch), cancellationToken: cancellationToken);
                     }
                     catch (Exception ex)
                     {
@@ -1027,6 +1032,14 @@ namespace Microsoft.BridgeToKubernetes.Library.Connect
             bool dirty = false;
             var patch = new JsonPatchDocument<V1Deployment>();
             var reversePatch = new JsonPatchDocument<V1Deployment>();
+            patch.ContractResolver = new DefaultContractResolver
+            {
+                NamingStrategy = new CamelCaseNamingStrategy()
+            };
+            reversePatch.ContractResolver = new DefaultContractResolver
+            {
+                NamingStrategy = new CamelCaseNamingStrategy()
+            };
             int containerIndex = deployment.Spec.Template.Spec.Containers.ToList().FindIndex(c => c.Name == container.Name);
 
             if (deployment.Spec.Replicas != null && deployment.Spec.Replicas.Value != 1)
@@ -1110,6 +1123,14 @@ namespace Microsoft.BridgeToKubernetes.Library.Connect
             bool dirty = false;
             var patch = new JsonPatchDocument<V1StatefulSet>();
             var reversePatch = new JsonPatchDocument<V1StatefulSet>();
+            patch.ContractResolver = new DefaultContractResolver
+            {
+                NamingStrategy = new CamelCaseNamingStrategy()
+            };
+            reversePatch.ContractResolver = new DefaultContractResolver
+            {
+                NamingStrategy = new CamelCaseNamingStrategy()
+            };
             int containerIndex = statefulSet.Spec.Template.Spec.Containers.ToList().FindIndex(c => c.Name == container.Name);
 
             if (statefulSet.Spec.Replicas != null && statefulSet.Spec.Replicas.Value != 1)


### PR DESCRIPTION
Upgrade to Kubernetes Client C# library 7.2.19 instroduced JSON regression because new version switches from using newtonsoft to system.text.json, but system.text.json does not support JsonPatch. Related: https://docs.microsoft.com/en-us/aspnet/core/web-api/jsonpatch?view=aspnetcore-6.0#add-support-for-json-patch-when-using-systemtextjson and https://github.com/dotnet/aspnetcore/issues/14035