### PR TITLE
remove the thirdparty notice txt from CLI

### DIFF
--- a/src/dsc/dsc.csproj
+++ b/src/dsc/dsc.csproj
@@ -121,7 +121,6 @@
   <ItemGroup>
     <None
       Include="
-        $(MSBuildThisFileDirectory)..\vscode\ThirdPartyNotices\ThirdPartyNotices.txt;
         $(MSBuildThisFileDirectory)..\resources\license.rtf">
       <CopyToPublishDirectory>Always</CopyToPublishDirectory>
     </None>


### PR DESCRIPTION
This is to fix the build error for dotnet where csproj was expecting file from vscode which was removed recently.