### PR TITLE
delay cancelation token by one second

### DIFF
--- a/src/dsc/Remoting/RemotingHelper.cs
+++ b/src/dsc/Remoting/RemotingHelper.cs
@@ -41,7 +41,7 @@ namespace Microsoft.BridgeToKubernetes.Exe.Remoting
         {
             try
             {
-                _appCancellationTokenSource?.Cancel();
+                _appCancellationTokenSource?.CancelAfter(1500);
             }
             catch (Exception e)
             {


### PR DESCRIPTION
In some occasions we see token hang up error when disconnecting bridge debugger. This is caused because on disconnect cancellation signal to tear down server is sent immediately, sometime before response is sent to the client. Adding a delay on cancellation token so http server has enough time to send ok before being teared down.