### PR TITLE
[DO NOT MERGE] Release binaries for Bridge CLI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,131 @@
+name: release binaries
+on: 
+  push:
+    tags:
+      - "v*.*.*"
+
+jobs:
+  build:
+    runs-on: windows-latest
+    strategy:
+      matrix:
+        mode: [osx-x64,linux-x64,win-x64]
+    steps:
+    - uses: actions/checkout@v3
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v2
+      with:
+        dotnet-version: 6.0.x
+    - name: Setup NuGet.exe for use with actions
+      uses: NuGet/setup-nuget@v1.0.6
+    - name: Restore dependencies using Nuget
+      run: nuget restore src\client.sln -Verbosity Normal -NonInteractive -ConfigFile src/nuget.config
+    - name: dotnet Publish for ${{ matrix.mode }}
+      run: dotnet publish src\dsc\dsc.csproj -c Release -r ${{ matrix.mode }} --no-restore --self-contained true --verbosity normal
+    - name: Build endpointmanagerlauncher
+      run: dotnet publish src\EndpointManagerLauncher\endpointmanagerlauncher.csproj -r win-x64 -c Release --no-restore
+    - name: Copy endpointmanagerlauncher
+      uses: Azure/powershell@v1
+      if: ${{ matrix.mode == 'win-x64' }}
+      with:
+        inlineScript: |
+          Copy-Item -Path ${{ github.workspace }}\src\EndpointManagerLauncher\bin\Release\netcoreapp3.1\win-x64\publish\ -Destination ${{ github.workspace }}\src\dsc\bin\Release\netcoreapp3.1\win-x64\publish\EndpointManagerLauncher -Recurse -Exclude **/*.pdb   
+        azPSVersion: '3.1.0'
+    - name: Download Kubectl
+      uses: Azure/powershell@v1
+      with:
+        inlineScript: |
+          if ('${{ matrix.mode }}' -eq 'win-x64') {
+            $url = 'https://storage.googleapis.com/kubernetes-release/release/v1.21.2/bin/windows/amd64/kubectl.exe'
+            $dir = 'win'
+            $file = 'kubectl.exe'
+          } elseif ('${{ matrix.mode }}' -eq 'osx-x64') {
+            $url = 'https://storage.googleapis.com/kubernetes-release/release/v1.21.2/bin/darwin/amd64/kubectl'
+            $dir = 'osx'
+            $file = 'kubectl'
+          } else {
+            $url = 'https://storage.googleapis.com/kubernetes-release/release/v1.21.2/bin/linux/amd64/kubectl'
+            $dir = 'linux'
+            $file = 'kubectl'
+          }
+          Write-Output "url is: "$url
+          Write-Output "directory is: "$dir
+          Write-Output "file is: "$file
+          New-Item -Path '${{ github.workspace }}\src\dsc\bin\Release\netcoreapp3.1\${{ matrix.mode }}\publish\kubectl' -ItemType Directory
+          $filePath = '${{ github.workspace }}\src\dsc\bin\Release\netcoreapp3.1\${{ matrix.mode }}\publish\kubectl\'+$dir
+          Write-Output "file path is: "$filePath
+          New-Item -Path $filePath -ItemType Directory
+          $fileName = $filePath + '\' + $file
+          Write-Output "file name is: "$fileName 
+          curl.exe $url -o $fileName
+        azPSVersion: '3.1.0'
+    - name: Create .Zip files (${{ matrix.mode }})
+      uses: TheDoctor0/zip-release@0.6.2
+      with:
+        type: 'zip'
+        filename: 'lpk-${{ matrix.mode }}.zip'
+        path: ${{ github.workspace }}\src\dsc\bin\Release\netcoreapp3.1\${{ matrix.mode }}\publish\**
+        exclusions: '**/*.pdb **/*.xml **/*.nuspec **/cs/* **/de/* **/es/* **/fr/* **/it/* **/ja/* **/ko/* **/pl/* **/pt-BR/* **/ru/* **/tr/* **/zh-Hans/* **/zh-Hant/*'
+    - name: Upload Release
+      uses: actions/upload-artifact@v3
+      with:
+        name: lpk-${{ matrix.mode }}
+        path: |
+          ${{ github.workspace }}\lpk-${{ matrix.mode }}.zip
+  release:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+    - uses: actions/checkout@v3
+    - name: Get version from tag
+      id: tag_name
+      run: |
+          echo ::set-output name=current_version::${GITHUB_REF#refs/tags/v}
+      shell: bash
+    - name: Get Changelog Entry
+      id: changelog_reader
+      uses: mindsers/changelog-reader-action@v2
+      with:
+        validation_level: warn
+        version: ${{ steps.tag_name.outputs.current_version }}
+        path: CHANGELOG.md
+    - name: Create Release
+      id: create_release
+      uses: actions/create-release@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        tag_name: ${{ steps.tag_name.outputs.current_version  }}
+        release_name: ${{ steps.tag_name.outputs.current_version  }}
+        draft: false
+        prerelease: false
+        body_path: CHANGELOG.md
+    - name: Download All artifacts
+      uses: actions/download-artifact@v3
+    - name: Upload Window Release Assets
+      uses: actions/upload-release-asset@v1 
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.create_release.outputs.upload_url }}
+        asset_path: ${{ github.workspace }}/lpk-win-x64/lpk-win-x64.zip
+        asset_name: lpk-win.zip
+        asset_content_type: application/zip
+    - name: Upload Linux Release Assets
+      uses: actions/upload-release-asset@v1 
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.create_release.outputs.upload_url }}
+        asset_path: ${{ github.workspace }}/lpk-linux-x64/lpk-linux-x64.zip
+        asset_name: lpk-linux.zip
+        asset_content_type: application/zip
+    - name: Upload OSX Release Assets
+      uses: actions/upload-release-asset@v1 
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.create_release.outputs.upload_url }}
+        asset_path: ${{ github.workspace }}/lpk-osx-x64/lpk-osx-x64.zip
+        asset_name: lpk-osx.zip
+        asset_content_type: application/zip

--- a/.gitignore
+++ b/.gitignore
@@ -348,3 +348,6 @@ MigrationBackup/
 
 # Ionide (cross platform F# VS Code tools) working folder
 .ionide/
+
+#vscode launch and tasks json
+.vscode/

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,26 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            // Use IntelliSense to find out which attributes exist for C# debugging
+            // Use hover for the description of the existing attributes
+            // For further information visit https://github.com/OmniSharp/omnisharp-vscode/blob/master/debugger-launchjson.md
+            "name": ".NET Core Launch (console)",
+            "type": "coreclr",
+            "request": "launch",
+            "preLaunchTask": "build",
+            // If you have changed target frameworks, make sure to update the program path.
+            "program": "${workspaceFolder}/samples/ConnectSQLDatabase/ConnectSQLDatabase/bin/Debug/netcoreapp3.1/ConnectSQLDatabase.dll",
+            "args": [],
+            "cwd": "${workspaceFolder}/samples/ConnectSQLDatabase/ConnectSQLDatabase",
+            // For more information about the 'console' field, see https://aka.ms/VSCode-CS-LaunchJson-Console
+            "console": "internalConsole",
+            "stopAtEntry": false
+        },
+        {
+            "name": ".NET Core Attach",
+            "type": "coreclr",
+            "request": "attach"
+        }
+    ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,41 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "build",
+            "command": "dotnet",
+            "type": "process",
+            "args": [
+                "build",
+                "${workspaceFolder}/samples/ConnectSQLDatabase/ConnectSQLDatabase/ConnectSQLDatabase.csproj",
+                "/property:GenerateFullPaths=true",
+                "/consoleloggerparameters:NoSummary"
+            ],
+            "problemMatcher": "$msCompile"
+        },
+        {
+            "label": "publish",
+            "command": "dotnet",
+            "type": "process",
+            "args": [
+                "publish",
+                "${workspaceFolder}/samples/ConnectSQLDatabase/ConnectSQLDatabase/ConnectSQLDatabase.csproj",
+                "/property:GenerateFullPaths=true",
+                "/consoleloggerparameters:NoSummary"
+            ],
+            "problemMatcher": "$msCompile"
+        },
+        {
+            "label": "watch",
+            "command": "dotnet",
+            "type": "process",
+            "args": [
+                "watch",
+                "run",
+                "--project",
+                "${workspaceFolder}/samples/ConnectSQLDatabase/ConnectSQLDatabase/ConnectSQLDatabase.csproj"
+            ],
+            "problemMatcher": "$msCompile"
+        }
+    ]
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog
+
+## [0.0.8] - 2022-08-15
+### Added
+- Initial Release from internal repo
+- Add github workflows for code ql, release and build
+
+## [0.0.21] - 2022-08-15
+### Added
+- Initial Release from internal repo
+- Add github workflows for code ql, release and build
+- Add kubectl library download step
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,8 @@
 # Changelog
 
-## [0.0.8] - 2022-08-15
+## [0.0.1] - 2022-08-16
 ### Added
 - Initial Release from internal repo
-- Add github workflows for code ql, release and build
-
-## [0.0.21] - 2022-08-15
-### Added
-- Initial Release from internal repo
-- Add github workflows for code ql, release and build
+- Add github workflows for code ql, release binaries
 - Add kubectl library download step
 


### PR DESCRIPTION
**Feature for releasing binaries via GitHub actions.**

- this feature releases binaries for three operating systems mac-OS, linux and windows.
- it also includes self-contained release ex includes the binaries required for bridge along with dotnet libraries, kubectl library.
- it also releases binaries as GitHub release with semantic versioning ex: 0.0.1
- Release to production happens only on creation of tag which is manual now so that we can keep control of release to production.
- Sample release from forked repo - https://github.com/hsubramanianaks/Bridge-To-Kubernetes/releases/tag/0.0.21

