### PR TITLE
Fixing port assignment for headless service

### DIFF
--- a/src/library.tests/PortMappingManagerTest.cs
+++ b/src/library.tests/PortMappingManagerTest.cs
@@ -10,6 +10,7 @@ using System.Threading;
 using Autofac;
 using FakeItEasy;
 using k8s.Models;
+using Microsoft.BridgeToKubernetes.Common.IO;
 using Microsoft.BridgeToKubernetes.Common.Kubernetes;
 using Microsoft.BridgeToKubernetes.Library.Connect;
 using Microsoft.BridgeToKubernetes.Library.Models;
@@ -18,14 +19,17 @@ using Xunit;
 
 namespace Microsoft.BridgeToKubernetes.Library.Tests
 {
-    public class WorkloadInformationProviderTests : TestsBase
+    public class PortMappingManagerTest : TestsBase
     {
         private IWorkloadInformationProvider _workloadInformationProvider;
+        private IPortMappingManager _portMappingManager;
 
-        public WorkloadInformationProviderTests()
+        public PortMappingManagerTest()
         {
             var remoteContainerConnectionDetails = new AsyncLazy<RemoteContainerConnectionDetails>(async () => _autoFake.Resolve<RemoteContainerConnectionDetails>());
             _workloadInformationProvider = _autoFake.Resolve<WorkloadInformationProvider>(TypedParameter.From(remoteContainerConnectionDetails));
+            A.CallTo(() => _autoFake.Resolve<IPlatform>().IsOSX).Returns(true);
+            _portMappingManager = _autoFake.Resolve<PortMappingManager>();
         }
 
         [Theory]
@@ -35,15 +39,23 @@ namespace Microsoft.BridgeToKubernetes.Library.Tests
         [InlineData(1, 3)]
         public async void GetReachableServicesAsync_HeadlessService(int numServices, int numAddresses)
         {
+            // Set up
             ConfigureHeadlessService(numServices: numServices, namingFunction: (i) => $"myapp-{i}", numAddresses: numAddresses, addressHostNamingFunction: (i) => $"Host-{i}");
-            var result = await _workloadInformationProvider.GetReachableEndpointsAsync(namespaceName: "", localProcessConfig: null, includeSameNamespaceServices: true, cancellationToken: default(CancellationToken));
-            Assert.Equal(numServices * (numAddresses + 1), result.Count());
-            foreach (var endpoint in result) {
-                if (endpoint.Ports.Any()) {
-                    Assert.Equal(endpoint.Ports.ElementAt(0).LocalPort, -1);
-                }
-            }
+            var endpoints = await _workloadInformationProvider.GetReachableEndpointsAsync(namespaceName: "", localProcessConfig: null, includeSameNamespaceServices: true, cancellationToken: default(CancellationToken));
             
+            // Method to be tested
+            endpoints = _portMappingManager.GetRemoteToFreeLocalPortMappings(endpoints);
+
+            // Verification
+            Assert.Equal(numServices * (numAddresses + 1), endpoints.Count());
+            var assignedPorts = new HashSet<int>();
+            foreach (var endpoint in endpoints) {
+                foreach (var port in endpoint.Ports) {
+                    Assert.NotEqual(port.LocalPort, -1);
+                    Assert.False(assignedPorts.Contains(port.LocalPort));
+                    assignedPorts.Add(port.LocalPort);
+                }
+            }   
         }
 
         private void ConfigureHeadlessService(int numServices, Func<int, string> namingFunction, int numAddresses, Func<int, string> addressHostNamingFunction)

--- a/src/library/Connect/WorkloadInformationProvider.cs
+++ b/src/library/Connect/WorkloadInformationProvider.cs
@@ -440,8 +440,6 @@ namespace Microsoft.BridgeToKubernetes.Library.Connect
                 var isInWorkloadNamespace = StringComparer.OrdinalIgnoreCase.Equals(endpoint.Metadata.Namespace(), workloadNamespace);
                 foreach (var subset in endpoint.Subsets)
                 {
-                    ports = subset.Ports?.Where(port => this._IsSupportedProtocol(port.Protocol, endpoint.Metadata.Name)).Select(p => new PortPair(remotePort: p.Port)).ToArray() ?? new PortPair[] { };
-
                     // Next, endpoint addresses can also specify their own host names. We add these as well
                     var addresses = subset.Addresses?.Where(a => !string.IsNullOrWhiteSpace(a?.Hostname));
                     if (addresses == null || !addresses.Any())
@@ -456,7 +454,7 @@ namespace Microsoft.BridgeToKubernetes.Library.Connect
                             DnsName = isInWorkloadNamespace ?
                                         $"{address.Hostname}.{endpoint.Metadata.Name}" :
                                         $"{address.Hostname}.{endpoint.Metadata.Name}.{endpoint.Metadata.Namespace()}",
-                            Ports = ports,
+                            Ports = subset.Ports?.Where(port => this._IsSupportedProtocol(port.Protocol, endpoint.Metadata.Name)).Select(p => new PortPair(remotePort: p.Port)).ToArray() ?? new PortPair[] { },
                             IsInWorkloadNamespace = isInWorkloadNamespace
                         });
                     }


### PR DESCRIPTION
Fix for https://github.com/Azure/Bridge-To-Kubernetes/issues/35

Summary: when headless services are used and useKubernetesServiceEnvironmentVariables is set, bridge assigns same port to multiple services. This leads to bridge failing later on when setting up forwarding. The reason why the multiple assignment happens is because we were using same ports object to initialize multiple endpoints. When the local port assignment happens later on, assigning port to one endpoint updates the endpoint of all of them (since ports object shares same place in memory). 

Fix: use new created ports object for each endpoint.

Verification: UTs have been added and end to end verification is in progress.