### PR TITLE
Fix Connect crash when headless service has endpoint with empty subsets

### DIFF
--- a/src/library.tests/PortMappingManagerTest.cs
+++ b/src/library.tests/PortMappingManagerTest.cs
@@ -37,7 +37,7 @@ namespace Microsoft.BridgeToKubernetes.Library.Tests
         [InlineData(5, 20)]
         [InlineData(10, 3)]
         [InlineData(1, 3)]
-        public async void GetReachableServicesAsync_HeadlessService(int numServices, int numAddresses)
+        public async void GetRemoteToFreeLocalPortMappings_HeadlessService(int numServices, int numAddresses)
         {
             // Set up
             ConfigureHeadlessService(numServices: numServices, namingFunction: (i) => $"myapp-{i}", numAddresses: numAddresses, addressHostNamingFunction: (i) => $"Host-{i}");

--- a/src/library.tests/WorkloadInformationProviderTests.cs
+++ b/src/library.tests/WorkloadInformationProviderTests.cs
@@ -37,7 +37,8 @@ namespace Microsoft.BridgeToKubernetes.Library.Tests
         {
             ConfigureHeadlessService(numServices: numServices, namingFunction: (i) => $"myapp-{i}", numAddresses: numAddresses, addressHostNamingFunction: (i) => $"Host-{i}");
             var result = await _workloadInformationProvider.GetReachableEndpointsAsync(namespaceName: "", localProcessConfig: null, includeSameNamespaceServices: true, cancellationToken: default(CancellationToken));
-            Assert.Equal(numServices * (numAddresses), result.Count());
+            // Doing numServices-1 when calculating because we are adding empty subset for one service and that will be skipped
+            Assert.Equal((numServices-1) * (numAddresses), result.Count());
             foreach (var endpoint in result) {
                 if (endpoint.Ports.Any()) {
                     Assert.Equal(endpoint.Ports.ElementAt(0).LocalPort, -1);
@@ -49,6 +50,8 @@ namespace Microsoft.BridgeToKubernetes.Library.Tests
         private void ConfigureHeadlessService(int numServices, Func<int, string> namingFunction, int numAddresses, Func<int, string> addressHostNamingFunction)
         {
             var serviceList = new List<V1Service>();
+            // introducing this variable so we can add an endpoint with empty subset to have crash coverage
+            bool addSubset = false;
             for (int i = 0; i < numServices; i++)
             {
                 serviceList.Add(new V1Service()
@@ -65,28 +68,39 @@ namespace Microsoft.BridgeToKubernetes.Library.Tests
                         Name = namingFunction(i)
                     }
                 });
-                var endPoint = new V1Endpoints()
-                {
-                    Subsets = new List<V1EndpointSubset>()
+                var subsets = new List<V1EndpointSubset>()
                         {
                             new V1EndpointSubset()
                             {
                                 Ports = new List<Corev1EndpointPort> { new Corev1EndpointPort(port: 80, protocol: "TCP") },
                                 Addresses =  new List<V1EndpointAddress>()
                             }
-                        },
+                        };
+                if (!addSubset) {
+                    subsets = null;
+                }
+                var endPoint = new V1Endpoints()
+                {
+                    Subsets = subsets,
                     Metadata = new V1ObjectMeta()
                     {
                         Name = $"{namingFunction(i)}"
                     }
                 };
-                for (int j = 0; j < numAddresses; j++)
-                {
-                    endPoint.Subsets[0].Addresses.Add(new V1EndpointAddress
+                if (addSubset) {
+                    for (int j = 0; j < numAddresses; j++)
                     {
-                        Hostname = addressHostNamingFunction(j)
-                    });
+                        endPoint.Subsets[0].Addresses.Add(new V1EndpointAddress
+                        {
+                            Hostname = addressHostNamingFunction(j)
+                        });
+                    }
                 }
+                else {
+                    // we only want to skip addign subset in one, the rest should have subsets
+                    addSubset = true;
+                }
+
                 A.CallTo(() => _autoFake.Resolve<IKubernetesClient>().GetEndpointInNamespaceAsync(namingFunction(i), A<string>._, A<CancellationToken>._)).Returns(endPoint);
             }
             A.CallTo(() => _autoFake.Resolve<IKubernetesClient>().ListServicesInNamespaceAsync(default, default, default)).WithAnyArguments().Returns(new V1ServiceList(serviceList));

--- a/src/library/Connect/WorkloadInformationProvider.cs
+++ b/src/library/Connect/WorkloadInformationProvider.cs
@@ -408,6 +408,11 @@ namespace Microsoft.BridgeToKubernetes.Library.Connect
                         continue;
                     }
 
+                    if (endpoint.Subsets == null) {
+                        _log.Info($"Skipping endpoint: '{endpoint.Metadata.Name}' for service '{s.Metadata.Name}' because it has empty subsets.");
+                        continue;
+                    }
+
                     if (!headlessServiceEndpointsToRouteMap.ContainsKey(getMapKey(endpoint.Metadata.Name, endpoint.Metadata.NamespaceProperty)))
                     {
                         headlessServiceEndpointsToRouteMap.TryAdd(getMapKey(endpoint.Metadata.Name, endpoint.Metadata.NamespaceProperty), endpoint);


### PR DESCRIPTION
Our code assumes that every endpoint for a headless service will have subsets associated with it. This causes crash if customer ever tries to connect Bridge to a cluster that has a headless service with an endpoint that does not have subsets defined.