### PR TITLE
Update how service name when adding environment variables

### DIFF
--- a/src/.vscode/launch.json
+++ b/src/.vscode/launch.json
@@ -1,6 +1,13 @@
 {
     "version": "0.2.0",
     "configurations": [
+        // This configuration is used together with task to attahed debuger when running dotnet test command
+        // More details on how to run it: // For more details: https://stackoverflow.com/questions/56290166/how-to-debug-dotnet-test-in-vs-code
+        {
+            "name": ".NET Core Attach",
+            "type": "coreclr",
+            "request": "attach"
+        },
         {
             // Use IntelliSense to find out which attributes exist for C# debugging
             // Use hover for the description of the existing attributes
@@ -8,12 +15,12 @@
             "name": "bridge",
             "type": "coreclr",
             "request": "launch",
-            "preLaunchTask": "BuildAndPublishWindows", // Replace by BuildAndPublishWindows as needed
+            "preLaunchTask": "BuildAndPublishMac", // Replace by BuildAndPublishWindows as needed
             // If you have changed target frameworks, make sure to update the program path.
             // Replace osx-x64 with win-x64 if you are running in windows
-            "program": "${workspaceFolder}/dsc/bin/Debug/netcoreapp3.1/win-x64/dsc.dll",
-            "args": ["connect", "--service", "bikesharingweb", "--local-port", "3000", "--namespace", "bikes"],
-            //"args": ["prep-connect", "--service", "stats-api"],// "--local-port", "3001", "--use-kubernetes-service-environment-variables"],
+            "program": "${workspaceFolder}/dsc/bin/Debug/netcoreapp3.1/osx-x64/dsc.dll",
+            "args": ["connect", "--service", "mi-webapp-service", "--local-port", "3000", "--namespace", "mi-webapp2", "--use-kubernetes-service-environment-variables"],
+            //"args": ["prep-connect", "--service", "stats-api"],// "--local-port", "3001", ],
             "env": {
                 "BRIDGE_ENVIRONMENT":"dev",
                 "BRIDGE_BINARYUTILITYVERSION":"v1",

--- a/src/.vscode/tasks.json
+++ b/src/.vscode/tasks.json
@@ -1,6 +1,31 @@
 {
     "version": "2.0.0",
     "tasks": [
+        // This task is to allow attaching debuger when running dotnet test command, update cwd if you are running UT in a different directory
+        // For more details: https://stackoverflow.com/questions/56290166/how-to-debug-dotnet-test-in-vs-code
+        { 
+            "label": ".NET Core Test with debugger", 
+            "type": "process", 
+            "isBackground": true, 
+            "command": "dotnet", 
+            "args": [ "test" ], 
+            "options": 
+                { 
+                    "cwd": "${workspaceFolder}/library.tests", 
+                    "env": 
+                    { 
+                        "VSTEST_HOST_DEBUG": "1" 
+                    }, 
+                }, 
+            "group": "test", "presentation": 
+                { 
+                    "echo": true,
+                    "reveal": "always",
+                    "focus": false,
+                    "panel": "shared"
+                },
+            "problemMatcher": [] 
+        },
         {
             "label": "build",
             "command": "dotnet",

--- a/src/library.tests/LocalEnvironmentManagerTests.cs
+++ b/src/library.tests/LocalEnvironmentManagerTests.cs
@@ -38,7 +38,12 @@ namespace Microsoft.BridgeToKubernetes.Library.Tests
             endpointInfo2.DnsName = "foo";
             endpointInfo2.LocalIP = System.Net.IPAddress.Parse("127.0.0.2");
             endpointInfo2.Ports = new Common.Models.Settings.PortPair[] { new Common.Models.Settings.PortPair(5049, 80)};
-            workloadInfo.ReachableEndpoints = new List<Common.Models.EndpointInfo>{endpointInfo1, endpointInfo2};
+            Common.Models.EndpointInfo endpointInfo3 = new Common.Models.EndpointInfo();
+            endpointInfo3.DnsName = "kubernetes.default";
+            endpointInfo3.LocalIP = System.Net.IPAddress.Parse("127.0.0.3");
+            endpointInfo3.Ports = new Common.Models.Settings.PortPair[] { new Common.Models.Settings.PortPair(5048, 80)};
+
+            workloadInfo.ReachableEndpoints = new List<Common.Models.EndpointInfo>{endpointInfo1, endpointInfo2, endpointInfo3};
             workloadInfo.EnvironmentVariables = new Dictionary<string, string>();
 
             // Execute
@@ -47,9 +52,10 @@ namespace Microsoft.BridgeToKubernetes.Library.Tests
             // Validate
             // We should add 8 entries per each service
             // Since one of the services is managed identity for bridge to kubernetes we should also add/update msi_enpoint variable
-            Assert.Equal(8*2 + 1, result.Count());
+            Assert.Equal(8*3 + 1, result.Count());
             ValidateService("foo", result, "tcp", "5049", "127.0.0.2");
             ValidateService(Common.Constants.ManagedIdentity.TargetServiceNameOnLocalMachine, result, "tcp", "5050", "127.0.0.1");
+            ValidateService("kubernetes", result, "tcp", "5048", "");
             Assert.True(StringComparer.OrdinalIgnoreCase.Equals(result[ManagedIdentity.MSI_ENDPOINT_EnvironmentVariable], "http://127.0.0.1:5050/metadata/identity/oauth2/token"));
             
         }

--- a/src/library/Connect/LocalEnvironmentManager.cs
+++ b/src/library/Connect/LocalEnvironmentManager.cs
@@ -441,9 +441,13 @@ namespace Microsoft.BridgeToKubernetes.Library.Connect
         /// <summary>
         /// Add Kubernetes environment variables to existing list of environment variables
         /// </summary>
-        private void _AddKubernetesServiceEnv(IDictionary<string, string> envVariables, string serviceName, string host, string protocol, int port)
+        private void _AddKubernetesServiceEnv(IDictionary<string, string> envVariables, string dnsName, string host, string protocol, int port)
         {
-            serviceName = serviceName.ToUpperInvariant();
+            dnsName = dnsName.ToUpperInvariant();
+            // because we are using dns name instead of service we have to retrieve it by splitting when needed
+            // If this ever cause issues we should consider larger refactor where we add serviceName member varaible to EndpointInfo class.
+            string serviceName = dnsName.Split(".").First();
+
             if (string.IsNullOrEmpty(protocol))
             {
                 protocol = "tcp";


### PR DESCRIPTION
When user uses useKubernetesServiceEnvironmentVariables, our code replaces IP associated with KUBERNETES_SERVICE_HOST env variable value with full host name. However, it was checking for ServiceName == KUBERNETES, but the code uses dnsName as service name and if the service being debugged is running in namepace outside default (where kubernestes service runs), the check wouldnt work.

This PR fixes this check, adds UTs coverage and adds task.json and launch.json updates so we can use VSCode debugger when running UTs.