### PR TITLE
Update pipelines to use parameters for signing type and telemetry type as selection by user

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -18,7 +18,6 @@ parameters:
     displayName: Signing Type
     default: 'test'
     values:
-    - none
     - test
     - real
   - name: TelemetryType
@@ -102,7 +101,6 @@ jobs:
   - task: MicroBuildSigningPlugin@3
     name: ''
     displayName: Install Signing Plugin
-    condition: and(succeeded(), ne(parameters.SignTypeToUse, 'none'))
     enabled: True
     inputs:
       signType: ${{ parameters.SignTypeToUse }}
@@ -276,7 +274,6 @@ jobs:
   - task: VSBuild@1
     name: ''
     displayName: Sign Files
-    condition: and(succeeded(), ne(parameters.SignTypeToUse, 'none'))
     enabled: True
     inputs:
       solution: src/client.signproj
@@ -568,7 +565,6 @@ jobs:
         Write-Host "##vso[task.setvariable variable=MicroBuild_NuPkgSigningEnabled]false"
   - task: MicroBuildSigningPlugin@3
     displayName: Install Signing Plugin
-    condition: and(succeeded(), ne(parameters.SignTypeToUse, 'none'))
     enabled: True
     inputs:
       signType: ${{ parameters.SignTypeToUse }}
@@ -672,7 +668,6 @@ jobs:
         curl https://dl.k8s.io/release/v1.21.2/bin/linux/amd64/kubectl  -OutFile $(Build.SourcesDirectory)/src/dsc/bin/${{ parameters.BuildConfiguration }}/net6.0/linux-x64/publish/kubectl/linux/kubectl
   - task: VSBuild@1
     displayName: Sign Files
-    condition: and(succeeded(), ne(parameters.SignTypeToUse, 'none'))
     enabled: True
     inputs:
       solution: src/client.signproj

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -276,7 +276,7 @@ jobs:
   - task: VSBuild@1
     name: ''
     displayName: Sign Files
-    condition: and(succeeded(), eq(parameters.RunTests, 'true'))
+    condition: and(succeeded(), ne(parameters.SignTypeToUse, 'none'))
     enabled: True
     inputs:
       solution: src/client.signproj
@@ -568,6 +568,8 @@ jobs:
         Write-Host "##vso[task.setvariable variable=MicroBuild_NuPkgSigningEnabled]false"
   - task: MicroBuildSigningPlugin@3
     displayName: Install Signing Plugin
+    condition: and(succeeded(), ne(parameters.SignTypeToUse, 'none'))
+    enabled: True
     inputs:
       signType: ${{ parameters.SignTypeToUse }}
       zipSources: false
@@ -670,6 +672,8 @@ jobs:
         curl https://dl.k8s.io/release/v1.21.2/bin/linux/amd64/kubectl  -OutFile $(Build.SourcesDirectory)/src/dsc/bin/${{ parameters.BuildConfiguration }}/net6.0/linux-x64/publish/kubectl/linux/kubectl
   - task: VSBuild@1
     displayName: Sign Files
+    condition: and(succeeded(), ne(parameters.SignTypeToUse, 'none'))
+    enabled: True
     inputs:
       solution: src/client.signproj
       msbuildArgs: /t:SignFiles /p:SignType=${{ parameters.SignTypeToUse }}

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,883 +1,884 @@
 # 'Allow scripts to access the OAuth token' was selected in pipeline.  Add the following YAML to any steps requiring access:
-#       env:
-#           MY_ACCESS_TOKEN: $(System.AccessToken)
-# Variable 'ArtifactServices.Symbol.AccountName' was defined in the Variables tab
-# Variable 'ArtifactServices.Symbol.PAT' was defined in the Variables tab
-# Variable 'ArtifactServices.Symbol.UseAAD' was defined in the Variables tab
-# Variable 'DropRoot' was defined in the Variables tab
-# Variable 'ForceProductionBuild' was defined in the Variables tab
-# Variable 'ForceStagingBuild' was defined in the Variables tab
-# Variable 'MSI_BuildVersion' was defined in the Variables tab
-# Variable 'RunTests' was defined in the Variables tab
-# Variable 'skipComponentGovernanceDetection' was defined in the Variables tab
-# Variable 'system.prefergit' was defined in the Variables tab
-# Variable 'TeamName' was defined in the Variables tab
-# Variable 'TelemetryType' was defined in the Variables tab
-parameters:
-  - name: SignTypeToUse
-    displayName: Signing Type
-    default: 'test'
-    values:
-    - test
-    - real
-  - name: TelemetryType
-    displayName: Telemetry Type so that correct application insights key is selected
-    default: 'TELEMETRY_DEVELOPMENT'
-    values:
-    - TELEMETRY_DEVELOPMENT
-    - TELEMETRY_STAGING
-    - TELEMETRY_PRODUCTION
-  - name: BuildConfiguration
-    displayName: BuildConfiguration to be used
-    default: 'Release'
-    values:
-    - Release
-    - Debug
-variables:
-- name: BuildParameters.dotnetversion
-  value: 6.0.x
-- name: BuildParameters.nugetversion
-  value: 5.9.x
-- name: TeamName
-  value: Mindaro
-- name: RunTests
-  value: True
-
-trigger:
-  branches:
-    include:
-    - refs/heads/main
-  batch: True
-name: $(date:yyyyMMdd)$(rev:.r)
-resources:
-  repositories:
-  - repository: self
-    type: git
-    ref: refs/heads/main
-jobs:
-- job: Phase_1
-  displayName: Run self-contained build (binaries V1, where the binaries are all bundled together)
-  timeoutInMinutes: 120
-  cancelTimeoutInMinutes: 1
-  pool:
-    name: 'VSEngSS-MicroBuild2022-1ES'
-    demands:
-    - msbuild
-    - visualstudio
-    - DotNetFramework
-  steps:
-  - checkout: self
-    clean: true
-    fetchTags: false
-    persistCredentials: True
-  - task: PowerShell@2
-    displayName: Set staging/prod build vars for signing and telemetry copy
-    enabled: True
-    inputs:
-      targetType: inline
-      script: >-
-        if ($env:ForceStagingBuild -eq "true" -And $env:ForceProductionBuild -eq "true") {
-          Write-Host "You can't do a Staging and Production build at the same time... Duh...."
-          exit 1
-        }
-
-
-        $branchName = $env:BUILD_SOURCEBRANCH
-
-        if ($branchName -eq "refs/heads/main") {
-            Write-Host "##vso[task.setvariable variable=TelemetryType]"{{ parameters.TelemetryType }}
-            Write-Host "Done setting the sign type and telemetry key instance for main branch"
-        }
-
-
-        Write-Host "Disabling NuGet package signing because it doesn't work, and we don't publish public NuGet packages"
-
-        Write-Host "##vso[task.setvariable variable=MicroBuild_NuPkgSigningEnabled]false"
-  - task: MicroBuildSigningPlugin@3
-    name: ''
-    displayName: Install Signing Plugin
-    enabled: True
-    inputs:
-      signType: ${{ parameters.SignTypeToUse }}
-      zipSources: false
-  - task: MicroBuildLocalizationPlugin@3
-    displayName: 'Install Localization Plugin'
-    enabled: True
-  - task: UseDotNet@2
-    displayName: Use .NET Core SDK 6.0.x
-    enabled: True
-    inputs:
-      version: $(BuildParameters.dotnetversion)
-      installationPath: $(Agent.TempDirectory)/dotnet
-  - task: DotNetCoreCLI@2
-    displayName: restore EndpointManager (Windows) (to download runtime pack)
-    enabled: True
-    inputs:
-      command: restore
-      projects: src\endpointmanager\endpointmanager.csproj
-      restoreArguments: -r win-x64
-      selectOrConfig: config
-      nugetConfigPath: src/nuget.config
-      externalEndpoints: dba0ba50-2d4e-4f12-9f5a-42a638da803b
-  - task: NuGetToolInstaller@1
-    name: ''
-    displayName: Use NuGet 5.9.x
-    enabled: True
-    inputs:
-      versionSpec: $(BuildParameters.nugetversion)
-  - task: NuGetCommand@2
-    name: ''
-    displayName: NuGet restore client.sln
-    enabled: True
-    inputs:
-      solution: src/client.sln
-      selectOrConfig: config
-      feedRestore: fc5819b5-ed1c-4a51-9766-a55ddb558d72
-      nugetConfigPath: src/nuget.config
-      externalEndpoints: dba0ba50-2d4e-4f12-9f5a-42a638da803b
-      verbosityRestore: Normal
-      searchPatternPush: $(Build.ArtifactStagingDirectory)/*.nupkg
-  - task: VSBuild@1
-    name: ''
-    displayName: Build client.sln for Loc and Tests
-    condition: and(succeeded(), eq(variables.RunTests, 'true'))
-    enabled: True
-    inputs:
-      solution: src/client.sln
-      msbuildArgs: -p:Localize=true -p:ConsumeEndpointManager=false
-      configuration: ${{ parameters.BuildConfiguration }}
-  - task: VSTest@2
-    displayName: Run Unit Tests
-    condition: and(succeeded(), eq(variables.RunTests, 'true'))
-    enabled: True
-    inputs:
-      testAssemblyVer2: '**\bin\${{ parameters.BuildConfiguration }}\*\*Tests.dll'
-      runSettingsFile: tests/unittests/dotnetcore.runsettings
-      runInParallel: true
-      codeCoverageEnabled: True
-      testRunTitle: Unit Tests
-      failOnMinTestsNotRun: true
-      rerunFailedTests: true
-  - task: CopyFiles@2
-    displayName: Collect Loc files
-    condition: and(succeeded(), eq(variables.RunTests, 'true'))
-    enabled: True
-    inputs:
-      Contents: >-
-        src/*/bin/*/*/localize/**/*
-
-        src/*/bin/**/*.lce
-
-        src/dsc/bin/*/*/dsc.dll
-
-        src/endpointmanager/bin/*/*/endpointmanager.dll
-
-        src/common/bin/*/*/Microsoft.BridgeToKubernetes.Common.dll
-
-        src/library/bin/*/*/Microsoft.BridgeToKubernetes.Library.dll
-      TargetFolder: $(Build.ArtifactStagingDirectory)/Loc
-      OverWrite: true
-  - task: PublishBuildArtifacts@1
-    displayName: 'Publish Artifact: Loc'
-    condition: and(succeeded(), eq(variables.RunTests, 'true'))
-    enabled: True
-    inputs:
-      PathtoPublish: $(Build.ArtifactStagingDirectory)/Loc
-      ArtifactName: Loc
-      TargetPath: '\\my\share\$(Build.DefinitionName)\$(Build.BuildNumber)'
-  - task: DotNetCoreCLI@2
-    displayName: publish DSC (Windows)
-    enabled: True
-    inputs:
-      command: publish
-      publishWebProjects: false
-      projects: src\dsc\dsc.csproj
-      arguments: -c ${{ parameters.BuildConfiguration }} -r win-x64 --no-restore --self-contained true --verbosity detailed
-      zipAfterPublish: false
-      modifyOutputPath: false
-      selectOrConfig: config
-  - task: DotNetCoreCLI@2
-    displayName: publish EndpointManagerLauncher(Windows)
-    enabled: True
-    inputs:
-      command: publish
-      publishWebProjects: false
-      projects: src\EndpointManagerLauncher\endpointmanagerlauncher.csproj
-      arguments: -c ${{ parameters.BuildConfiguration }} -r win-x64 --no-restore --verbosity detailed
-      zipAfterPublish: false
-      modifyOutputPath: false
-      selectOrConfig: config
-  - task: CopyFiles@2
-    displayName: Copy EndpointManager Launcher to dsc folder
-    enabled: True
-    inputs:
-      SourceFolder: src/EndpointManagerLauncher/bin/${{ parameters.BuildConfiguration }}/net6.0/win-x64/publish/
-      Contents: >-
-        **/*
-
-        !**/*.pdb
-      TargetFolder: src/dsc/bin/${{ parameters.BuildConfiguration }}/net6.0/win-x64/publish/EndpointManagerLauncher
-      OverWrite: true
-  - task: DotNetCoreCLI@2
-    displayName: publish DSC (OSX)
-    enabled: True
-    inputs:
-      command: publish
-      publishWebProjects: false
-      projects: src\dsc\dsc.csproj
-      arguments: -c ${{ parameters.BuildConfiguration }} -r osx-x64 --no-restore --self-contained true --verbosity detailed
-      zipAfterPublish: false
-      modifyOutputPath: false
-      selectOrConfig: config
-  - task: DotNetCoreCLI@2
-    displayName: publish DSC (Linux)
-    enabled: True
-    inputs:
-      command: publish
-      publishWebProjects: false
-      projects: src\dsc\dsc.csproj
-      arguments: -c ${{ parameters.BuildConfiguration }} -r linux-x64 --no-restore --self-contained true --verbosity detailed
-      zipAfterPublish: false
-      modifyOutputPath: false
-      selectOrConfig: config
-  - task: PowerShell@2
-    displayName: Download kubectl
-    continueOnError: True
-    enabled: True
-    inputs:
-      targetType: inline
-      script: >
-        New-Item -Path './src/dsc/bin/${{ parameters.BuildConfiguration }}/net6.0/win-x64/publish/kubectl' -ItemType Directory
-
-        New-Item -Path './src/dsc/bin/${{ parameters.BuildConfiguration }}/net6.0/win-x64/publish/kubectl/win' -ItemType Directory
-
-        curl https://dl.k8s.io/release/v1.21.2/bin/windows/amd64/kubectl.exe -OutFile ./src/dsc/bin/${{ parameters.BuildConfiguration }}/net6.0/win-x64/publish/kubectl/win/kubectl.exe
-
-
-        New-Item -Path './src/dsc/bin/${{ parameters.BuildConfiguration }}/net6.0/osx-x64/publish/kubectl' -ItemType Directory
-
-        New-Item -Path './src/dsc/bin/${{ parameters.BuildConfiguration }}/net6.0/osx-x64/publish/kubectl/osx' -ItemType Directory
-
-        curl https://dl.k8s.io/release/v1.21.2/bin/darwin/amd64/kubectl  -OutFile ./src/dsc/bin/${{ parameters.BuildConfiguration }}/net6.0/osx-x64/publish/kubectl/osx/kubectl
-
-
-        New-Item -Path './src/dsc/bin/${{ parameters.BuildConfiguration }}/net6.0/linux-x64/publish/kubectl' -ItemType Directory
-
-        New-Item -Path './src/dsc/bin/${{ parameters.BuildConfiguration }}/net6.0/linux-x64/publish/kubectl/linux' -ItemType Directory
-
-        curl https://dl.k8s.io/release/v1.21.2/bin/linux/amd64/kubectl  -OutFile ./src/dsc/bin/${{ parameters.BuildConfiguration }}/net6.0/linux-x64/publish/kubectl/linux/kubectl
-  - task: VSBuild@1
-    name: ''
-    displayName: Sign Files
-    enabled: True
-    inputs:
-      solution: src/client.signproj
-      msbuildArgs: /t:SignFiles /p:SignType=${{ parameters.SignTypeToUse }}
-      configuration: '${{ parameters.BuildConfiguration }} '
-  - task: CopyFiles@2
-    displayName: Collect files for .zip (Windows)
-    enabled: True
-    inputs:
-      SourceFolder: src/dsc/bin/${{ parameters.BuildConfiguration }}/net6.0/win-x64/publish
-      Contents: >-
-        **/*
-
-        !**/*.pdb
-
-        !**/*.xml
-
-        !**/*.nuspec
-
-        !**/cs/*
-
-        !**/de/*
-
-        !**/es/*
-
-        !**/fr/*
-
-        !**/it/*
-
-        !**/ja/*
-
-        !**/ko/*
-
-        !**/pl/*
-
-        !**/pt-BR/*
-
-        !**/ru/*
-
-        !**/tr/*
-
-        !**/zh-Hans/*
-
-        !**/zh-Hant/*
-      TargetFolder: $(Agent.TempDirectory)/zip/win
-  - task: CopyFiles@2
-    displayName: Collect files for .zip (OSX)
-    enabled: True
-    inputs:
-      SourceFolder: src/dsc/bin/${{ parameters.BuildConfiguration }}/net6.0/osx-x64/publish
-      Contents: >-
-        **/*
-
-        src/resources/license.rtf
-
-        src/vscode/ThirdPartyNotices.txt
-
-        !**/*.pdb
-
-        !**/*.xml
-
-        !**/*.nuspec
-
-        !**/cs/*
-
-        !**/de/*
-
-        !**/es/*
-
-        !**/fr/*
-
-        !**/it/*
-
-        !**/ja/*
-
-        !**/ko/*
-
-        !**/pl/*
-
-        !**/pt-BR/*
-
-        !**/ru/*
-
-        !**/tr/*
-
-        !**/zh-Hans/*
-
-        !**/zh-Hant/*
-      TargetFolder: $(Agent.TempDirectory)/zip/osx
-  - task: CopyFiles@2
-    displayName: Collect files for .zip (Linux)
-    enabled: True
-    inputs:
-      SourceFolder: src/dsc/bin/${{ parameters.BuildConfiguration }}/net6.0/linux-x64/publish
-      Contents: >-
-        **/*
-
-        src/resources/license.rtf
-
-        src/vscode/ThirdPartyNotices.txt
-
-        !**/*.pdb
-
-        !**/*.xml
-
-        !**/*.nuspec
-
-        !**/cs/*
-
-        !**/de/*
-
-        !**/es/*
-
-        !**/fr/*
-
-        !**/it/*
-
-        !**/ja/*
-
-        !**/ko/*
-
-        !**/pl/*
-
-        !**/pt-BR/*
-
-        !**/ru/*
-
-        !**/tr/*
-
-        !**/zh-Hans/*
-
-        !**/zh-Hant/*
-      TargetFolder: $(Agent.TempDirectory)/zip/linux
-  - task: ArchiveFiles@2
-    displayName: Create .zip file (Windows)
-    enabled: True
-    inputs:
-      rootFolderOrFile: $(Agent.TempDirectory)/zip/win
-      includeRootFolder: false
-      sevenZipCompression: 5
-      archiveFile: $(Build.ArtifactStagingDirectory)/zip/lpk-win.zip
-  - task: ArchiveFiles@2
-    displayName: Create .zip file (OSX)
-    enabled: True
-    inputs:
-      rootFolderOrFile: $(Agent.TempDirectory)/zip/osx
-      includeRootFolder: false
-      sevenZipCompression: 5
-      archiveFile: $(Build.ArtifactStagingDirectory)/zip/lpk-osx.zip
-  - task: ArchiveFiles@2
-    displayName: Create .zip file (Linux)
-    enabled: True
-    inputs:
-      rootFolderOrFile: $(Agent.TempDirectory)/zip/linux
-      includeRootFolder: false
-      sevenZipCompression: 5
-      archiveFile: $(Build.ArtifactStagingDirectory)/zip/lpk-linux.zip
-  - task: PowerShell@2
-    displayName: Generate lks.json for .zip files
-    enabled: True
-    inputs:
-      targetType: inline
-      script: >-
-        $ZipHost = "mindaromaster.blob.core.windows.net"
-
-        $BlobUrl = "https://$ZipHost/zip/1.0.$env:BUILD_BUILDNUMBER"
-
-        $ZipDir = "$env:BUILD_ARTIFACTSTAGINGDIRECTORY/zip"
-
-        $Win = @{ url="$BlobUrl/lpk-win.zip"; sha256hash="$((Get-FileHash $ZipDir\lpk-win.zip).Hash)" }
-
-        $OSX = @{ url="$BlobUrl/lpk-osx.zip"; sha256hash="$((Get-FileHash $ZipDir\lpk-osx.zip).Hash)" }
-
-        $Linux = @{ url="$BlobUrl/lpk-linux.zip"; sha256hash="$((Get-FileHash $ZipDir\lpk-linux.zip).Hash)" }
-
-        $Json = @{ version="1.0.$env:BUILD_BUILDNUMBER"; win = $Win; osx = $OSX; linux = $Linux } | ConvertTo-Json
-
-        $Json | Out-File -FilePath $ZipDir/lks.json -Encoding ascii
-
-        New-Item -ItemType directory -Path $ZipDir/1.0.$env:BUILD_BUILDNUMBER
-
-        $Json | Out-File -FilePath $ZipDir/1.0.$env:BUILD_BUILDNUMBER/lks.json -Encoding ascii
-
-        Write-Host $Json
-  - task: ManifestGeneratorTask@0
-    displayName: Manifest Generator for zip
-    enabled: True
-    inputs:
-      BuildDropPath: $(Build.ArtifactStagingDirectory)/zip
-  - task: PublishBuildArtifacts@1
-    displayName: 'Publish Artifact: zip'
-    enabled: True
-    inputs:
-      PathtoPublish: $(Build.ArtifactStagingDirectory)/zip
-      ArtifactName: zip
-      TargetPath: '\\my\share\$(Build.DefinitionName)\$(Build.BuildNumber)'
-  - task: DotNetCoreCLI@2
-    displayName: 'dotnet pack CLI NuGet (Windows)'
-    inputs:
-      command: pack
-      feedsToUse: config
-      packagesToPack: src/dsc/dsc.csproj
-      packDirectory: '$(Build.ArtifactStagingDirectory)/nuget'
-      nobuild: true
-      buildProperties: 'NuspecFile=bin\${{ parameters.BuildConfiguration }}\net6.0\win-x64\publish\dsc.nuspec'
-  - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
-    displayName: 'Manifest Generator for nuget'
-    inputs:
-      BuildDropPath: '$(Build.ArtifactStagingDirectory)/nuget'
-  - task: PublishBuildArtifacts@1
-    displayName: 'Publish Artifact: nuget'
-    inputs:
-      PathtoPublish: '$(Build.ArtifactStagingDirectory)/nuget'
-      ArtifactName: nuget
-  - task: CopyFiles@2
-    displayName: Collect Build Symbols - dsc
-    enabled: True
-    inputs:
-      SourceFolder: src/dsc/bin/${{ parameters.BuildConfiguration }}/net6.0
-      Contents: >-
-        */publish/dsc.?(pdb|exe|dll|)
-
-        */publish/Microsoft.BridgeToKubernetes.*.@(pdb|exe|dll|)
-
-        */publish/EndpointManager/EndpointManager.?(pdb|exe|dll|)
-
-        */publish/EndpointManager/Microsoft.BridgeToKubernetes.*.@(pdb|exe|dll|)
-      TargetFolder: $(Build.ArtifactStagingDirectory)/symbols
-      OverWrite: true
-  - task: PublishSymbols@2
-    displayName: Enable Source Server
-    condition: and(succeeded(), eq(variables.RunTests, 'true'))
-    enabled: True
-    inputs:
-      SymbolsFolder: $(Build.ArtifactStagingDirectory)/symbols
-      SearchPattern: '**/*.pdb'
-      SymbolServerType: TeamServices
-  - task: CopyFiles@2
-    displayName: Copy buildWindowsPDBs.ps1 to artifact directory
-    enabled: True
-    inputs:
-      SourceFolder: build
-      Contents: buildWindowsPDBs.ps1
-      TargetFolder: $(Build.ArtifactStagingDirectory)/symbols/
-      OverWrite: true
-  - task: PublishBuildArtifacts@1
-    displayName: 'Publish Artifact: symbols'
-    condition: and(succeeded(), eq(variables.RunTests, 'true'))
-    enabled: True
-    inputs:
-      PathtoPublish: $(Build.ArtifactStagingDirectory)/symbols
-      ArtifactName: symbols
-      TargetPath: '\\my\share\$(Build.DefinitionName)\$(Build.BuildNumber)'
-  - task: tagBuildOrRelease@0
-    displayName: Tag BuildConfiguration
-    enabled: True
-    inputs:
-      tags: 'BuildConfiguration: ${{ parameters.BuildConfiguration }}'
-- job: Phase_2
-  displayName: Run NON self-contained build (binaries V2, where the binaries are downloaded in parallel)
-  timeoutInMinutes: 120
-  cancelTimeoutInMinutes: 1
-  pool:
-    name: 'VSEngSS-MicroBuild2022-1ES'
-    demands:
-    - msbuild
-    - visualstudio
-    - vstest
-  steps:
-  - checkout: self
-    clean: true
-    fetchTags: false
-    persistCredentials: True
-  - task: PowerShell@2
-    displayName: Set staging/prod build vars for signing and telemetry
-    inputs:
-      targetType: inline
-      script: >-
-        $branchName = $env:BUILD_SOURCEBRANCH
-
-        if ($branchName -eq "refs/heads/main") {
-            Write-Host "##vso[task.setvariable variable=TelemetryType]"{{ parameters.TelemetryType }}
-            Write-Host "Done setting the sign type and telemetry key instance for staging branch"
-        }
-
-        Write-Host "Disabling NuGet package signing because it doesn't work, and we don't publish public NuGet packages"
-
-        Write-Host "##vso[task.setvariable variable=MicroBuild_NuPkgSigningEnabled]false"
-  - task: MicroBuildSigningPlugin@3
-    displayName: Install Signing Plugin
-    enabled: True
-    inputs:
-      signType: ${{ parameters.SignTypeToUse }}
-      zipSources: false
-  - task: MicroBuildLocalizationPlugin@3
-    displayName: Install Localization Plugin
-  - task: UseDotNet@2
-    displayName: Use .NET Core SDK 6.0.X
-    inputs:
-      version: 6.0.306
-      installationPath: $(Agent.TempDirectory)/dotnet
-  - task: DotNetCoreCLI@2
-    displayName: restore EndpointManager (Windows) (to download runtime pack)
-    inputs:
-      command: restore
-      projects: src\endpointmanager\endpointmanager.csproj
-      restoreArguments: -r win-x64
-      selectOrConfig: config
-      nugetConfigPath: src/nuget.config
-      externalEndpoints: dba0ba50-2d4e-4f12-9f5a-42a638da803b
-  - task: NuGetToolInstaller@1
-    displayName: Use NuGet 6.1.x
-    inputs:
-      versionSpec: 6.1.x
-  - task: NuGetCommand@2
-    displayName: NuGet restore client.sln
-    inputs:
-      solution: src/client.sln
-      selectOrConfig: config
-      nugetConfigPath: src/nuget.config
-      externalEndpoints: dba0ba50-2d4e-4f12-9f5a-42a638da803b
-  - task: DotNetCoreCLI@2
-    displayName: publish DSC (Windows)
-    inputs:
-      command: publish
-      publishWebProjects: false
-      projects: src\dsc\dsc.csproj
-      arguments: -c ${{ parameters.BuildConfiguration }} -r win-x64 --self-contained false --no-restore --verbosity detailed
-      zipAfterPublish: false
-      modifyOutputPath: false
-  - task: CmdLine@2
-    displayName: Build EndpointManager Launcher using .Net 5
-    inputs:
-      script: >-
-        echo "Publishing EndpointManager Launcher..."
-
-        "C:\Program Files\dotnet\dotnet.exe" publish src\EndpointManagerLauncher\endpointmanagerlauncher.csproj -r win-x64 -c Release --no-restore
-
-        echo "Done publishing EndpointManager Launcher..."
-  - task: CopyFiles@2
-    displayName: Copy EndpointManager Launcher to dsc folder
-    inputs:
-      SourceFolder: src/EndpointManagerLauncher/bin/${{ parameters.BuildConfiguration }}/net6.0/win-x64/publish/
-      Contents: >-
-        **/*
-
-        !**/*.pdb
-      TargetFolder: src/dsc/bin/${{ parameters.BuildConfiguration }}/net6.0/win-x64/publish/EndpointManagerLauncher
-  - task: DotNetCoreCLI@2
-    displayName: publish DSC (OSX)
-    inputs:
-      command: publish
-      publishWebProjects: false
-      projects: src\dsc\dsc.csproj
-      arguments: -c ${{ parameters.BuildConfiguration }} -r osx-x64 --no-restore --self-contained false --verbosity detailed
-      zipAfterPublish: false
-      modifyOutputPath: false
-  - task: DotNetCoreCLI@2
-    displayName: publish DSC (Linux)
-    inputs:
-      command: publish
-      publishWebProjects: false
-      projects: src\dsc\dsc.csproj
-      arguments: -c ${{ parameters.BuildConfiguration }} -r linux-x64 --no-restore --self-contained false --verbosity detailed
-      zipAfterPublish: false
-      modifyOutputPath: false
-  - task: PowerShell@2
-    displayName: Download kubectl
-    continueOnError: True
-    inputs:
-      targetType: inline
-      script: >
-        New-Item -Path '$(Build.SourcesDirectory)/src/dsc/bin/${{ parameters.BuildConfiguration }}/net6.0/win-x64/publish/kubectl' -ItemType Directory
-
-        New-Item -Path '$(Build.SourcesDirectory)/src/dsc/bin/${{ parameters.BuildConfiguration }}/net6.0/win-x64/publish/kubectl/win' -ItemType Directory
-
-        curl https://dl.k8s.io/release/v1.21.2/bin/windows/amd64/kubectl.exe -OutFile $(Build.SourcesDirectory)/src/dsc/bin/${{ parameters.BuildConfiguration }}/net6.0/win-x64/publish/kubectl/win/kubectl.exe
-
-
-        New-Item -Path '$(Build.SourcesDirectory)/src/dsc/bin/${{ parameters.BuildConfiguration }}/net6.0/osx-x64/publish/kubectl' -ItemType Directory
-
-        New-Item -Path '$(Build.SourcesDirectory)/src/dsc/bin/${{ parameters.BuildConfiguration }}/net6.0/osx-x64/publish/kubectl/osx' -ItemType Directory
-
-        curl https://dl.k8s.io/release/v1.21.2/bin/darwin/amd64/kubectl  -OutFile $(Build.SourcesDirectory)/src/dsc/bin/${{ parameters.BuildConfiguration }}/net6.0/osx-x64/publish/kubectl/osx/kubectl
-
-
-        New-Item -Path '$(Build.SourcesDirectory)/src/dsc/bin/${{ parameters.BuildConfiguration }}/net6.0/linux-x64/publish/kubectl' -ItemType Directory
-
-        New-Item -Path '$(Build.SourcesDirectory)/src/dsc/bin/${{ parameters.BuildConfiguration }}/net6.0/linux-x64/publish/kubectl/linux' -ItemType Directory
-
-        curl https://dl.k8s.io/release/v1.21.2/bin/linux/amd64/kubectl  -OutFile $(Build.SourcesDirectory)/src/dsc/bin/${{ parameters.BuildConfiguration }}/net6.0/linux-x64/publish/kubectl/linux/kubectl
-  - task: VSBuild@1
-    displayName: Sign Files
-    enabled: True
-    inputs:
-      solution: src/client.signproj
-      msbuildArgs: /t:SignFiles /p:SignType=${{ parameters.SignTypeToUse }}
-      configuration: '${{ parameters.BuildConfiguration }} '
-  - task: CopyFiles@2
-    displayName: Collect files for .zip (Windows)
-    inputs:
-      SourceFolder: src/dsc/bin/${{ parameters.BuildConfiguration }}/net6.0/win-x64/publish
-      Contents: >-
-        **/*
-
-        !**/*.pdb
-
-        !**/*.xml
-
-        !**/*.nuspec
-
-        !**/cs/*
-
-        !**/de/*
-
-        !**/es/*
-
-        !**/fr/*
-
-        !**/it/*
-
-        !**/ja/*
-
-        !**/ko/*
-
-        !**/pl/*
-
-        !**/pt-BR/*
-
-        !**/ru/*
-
-        !**/tr/*
-
-        !**/zh-Hans/*
-
-        !**/zh-Hant/*
-      TargetFolder: $(Agent.TempDirectory)/zip/win
-  - task: CopyFiles@2
-    displayName: Collect files for .zip (OSX)
-    inputs:
-      SourceFolder: src/dsc/bin/${{ parameters.BuildConfiguration }}/net6.0/osx-x64/publish
-      Contents: >-
-        **/*
-
-        src/resources/license.rtf
-
-        src/vscode/ThirdPartyNotices.txt
-
-        !**/*.pdb
-
-        !**/*.xml
-
-        !**/*.nuspec
-
-        !**/cs/*
-
-        !**/de/*
-
-        !**/es/*
-
-        !**/fr/*
-
-        !**/it/*
-
-        !**/ja/*
-
-        !**/ko/*
-
-        !**/pl/*
-
-        !**/pt-BR/*
-
-        !**/ru/*
-
-        !**/tr/*
-
-        !**/zh-Hans/*
-
-        !**/zh-Hant/*
-      TargetFolder: $(Agent.TempDirectory)/zip/osx
-  - task: CopyFiles@2
-    displayName: Collect files for .zip (Linux)
-    inputs:
-      SourceFolder: src/dsc/bin/${{ parameters.BuildConfiguration }}/net6.0/linux-x64/publish
-      Contents: >-
-        **/*
-
-        src/resources/license.rtf
-
-        src/vscode/ThirdPartyNotices.txt
-
-        !**/*.pdb
-
-        !**/*.xml
-
-        !**/*.nuspec
-
-        !**/cs/*
-
-        !**/de/*
-
-        !**/es/*
-
-        !**/fr/*
-
-        !**/it/*
-
-        !**/ja/*
-
-        !**/ko/*
-
-        !**/pl/*
-
-        !**/pt-BR/*
-
-        !**/ru/*
-
-        !**/tr/*
-
-        !**/zh-Hans/*
-
-        !**/zh-Hant/*
-      TargetFolder: $(Agent.TempDirectory)/zip/linux
-  - task: ArchiveFiles@2
-    displayName: Create .zip file (Windows)
-    inputs:
-      rootFolderOrFile: $(Agent.TempDirectory)/zip/win
-      includeRootFolder: false
-      sevenZipCompression: 5
-      archiveFile: $(Build.ArtifactStagingDirectory)/zip/lpk-win.zip
-  - task: ArchiveFiles@2
-    displayName: Create .zip file (OSX)
-    inputs:
-      rootFolderOrFile: $(Agent.TempDirectory)/zip/osx
-      includeRootFolder: false
-      sevenZipCompression: 5
-      archiveFile: $(Build.ArtifactStagingDirectory)/zip/lpk-osx.zip
-  - task: ArchiveFiles@2
-    displayName: Create .zip file (Linux)
-    inputs:
-      rootFolderOrFile: $(Agent.TempDirectory)/zip/linux
-      includeRootFolder: false
-      sevenZipCompression: 5
-      archiveFile: $(Build.ArtifactStagingDirectory)/zip/lpk-linux.zip
-  - task: PowerShell@2
-    displayName: Generate lks.json for .zip files
-    inputs:
-      targetType: inline
-      script: >
-        $ZipHost = "mindaromaster.blob.core.windows.net"
-
-        $BlobUrl = "https://$ZipHost/zipv2/1.0.$env:BUILD_BUILDNUMBER"
-
-        $BlobLKSUrl = "https://$ZipHost/zipv2/LKS"
-
-        $ZipDir = "$env:BUILD_ARTIFACTSTAGINGDIRECTORY/zip"
-
-        # CLI binaries
-
-        $Cli_Win = @{ url="$BlobUrl/lpk-win.zip"; sha256hash="$((Get-FileHash $ZipDir\lpk-win.zip).Hash)" }
-
-        $Cli_Osx = @{ url="$BlobUrl/lpk-osx.zip"; sha256hash="$((Get-FileHash $ZipDir\lpk-osx.zip).Hash)" }
-
-        $Cli_Linux = @{ url="$BlobUrl/lpk-linux.zip"; sha256hash="$((Get-FileHash $ZipDir\lpk-linux.zip).Hash)" }
-
-        # Kubectl binaries
-
-        $Kubectl_Win = @{ url="$BlobLKSUrl/kubectl-win.zip"; sha256hash="5490F9B60E4C2C4229CA00FBFA946AE65655F0739BE9714C6A0A0FB7BE2A6F2C" }
-
-        $Kubectl_Osx = @{ url="$BlobLKSUrl/kubectl-osx.zip"; sha256hash="D24EAFEC39EB2393DBA0088B762953BEDCC04156AC9E324FA290476BD3C888B9" }
-
-        $Kubectl_Linux = @{ url="$BlobLKSUrl/kubectl-linux.zip"; sha256hash="01B76D4E4A9081452932F27C767C9D8F3507C8AD3CC9269CEB16729F4D0ED900" }
-
-        #dotnet runtime binaries
-
-        $Dotnet_Win = @{ url="$BlobLKSUrl/dotnetruntime-win.zip"; sha256hash="0FCA9F2AB829C85615007EA646CF436D2E90C9A4095C84C2F9EB3EC0754468A8" }
-
-        $Dotnet_Osx = @{ url="$BlobLKSUrl/dotnetruntime-osx.zip"; sha256hash="D25F8BB708C364678AAA0F3798F5EADD1BE46800376F15D2F12C785C74AF8443" }
-
-        $Dotnet_Linux = @{ url="$BlobLKSUrl/dotnetruntime-linux.zip"; sha256hash="801D9D251D07B9A88195450FCBFD70C7507CEEEF05D5F0E88CC14CEBFCC10F4B" }
-
-        # Win Json
-
-        $Win = @{ dotnetruntime = $Dotnet_Win; kubectl = $Kubectl_Win; bridge = $Cli_Win }
-
-        # OSX Json
-
-        $OSX = @{ dotnetruntime = $Dotnet_Osx; kubectl = $Kubectl_Osx; bridge = $Cli_Osx }
-
-        # Linux Json
-
-        $Linux = @{ dotnetruntime = $Dotnet_Linux; kubectl = $Kubectl_Linux; bridge = $Cli_Linux }
-
-        $Json = @{ version="1.0.$env:BUILD_BUILDNUMBER"; win = $Win; osx = $OSX; linux = $Linux } | ConvertTo-Json
-
-        $Json | Out-File -FilePath $ZipDir/lks.json -Encoding ascii
-
-        New-Item -ItemType directory -Path $ZipDir/1.0.$env:BUILD_BUILDNUMBER
-
-        $Json | Out-File -FilePath $ZipDir/1.0.$env:BUILD_BUILDNUMBER/lks.json -Encoding ascii
-
-        Write-Host $Json
-  - task: ManifestGeneratorTask@0
-    displayName: Manifest Generator for zip
-    inputs:
-      BuildDropPath: $(Build.ArtifactStagingDirectory)/zip/
-  - task: PublishBuildArtifacts@1
-    displayName: Generate lks.json for .zip files
-    inputs:
-      PathtoPublish: $(Build.ArtifactStagingDirectory)/zip
-      ArtifactName: zipv2
-...
+    #       env:
+    #           MY_ACCESS_TOKEN: $(System.AccessToken)
+    # Variable 'ArtifactServices.Symbol.AccountName' was defined in the Variables tab
+    # Variable 'ArtifactServices.Symbol.PAT' was defined in the Variables tab
+    # Variable 'ArtifactServices.Symbol.UseAAD' was defined in the Variables tab
+    # Variable 'DropRoot' was defined in the Variables tab
+    # Variable 'ForceProductionBuild' was defined in the Variables tab
+    # Variable 'ForceStagingBuild' was defined in the Variables tab
+    # Variable 'MSI_BuildVersion' was defined in the Variables tab
+    # Variable 'RunTests' was defined in the Variables tab
+    # Variable 'skipComponentGovernanceDetection' was defined in the Variables tab
+    # Variable 'system.prefergit' was defined in the Variables tab
+    # Variable 'TeamName' was defined in the Variables tab
+    # Variable 'TelemetryType' was defined in the Variables tab
+    parameters:
+      - name: SignTypeToUse
+        displayName: Signing Type
+        default: 'test'
+        values:
+        - test
+        - real
+      - name: TelemetryType
+        displayName: Telemetry Type so that correct application insights key is selected
+        default: 'TELEMETRY_DEVELOPMENT'
+        values:
+        - TELEMETRY_DEVELOPMENT
+        - TELEMETRY_STAGING
+        - TELEMETRY_PRODUCTION
+      - name: BuildConfiguration
+        displayName: BuildConfiguration to be used
+        default: 'Release'
+        values:
+        - Release
+        - Debug
+    variables:
+    - name: BuildParameters.dotnetversion
+      value: 6.0.x
+    - name: BuildParameters.nugetversion
+      value: 5.9.x
+    - name: TeamName
+      value: Mindaro
+    - name: RunTests
+      value: True
+    
+    trigger:
+      branches:
+        include:
+        - refs/heads/main
+      batch: True
+    name: $(date:yyyyMMdd)$(rev:.r)
+    resources:
+      repositories:
+      - repository: self
+        type: git
+        ref: refs/heads/main
+    jobs:
+    - job: Phase_1
+      displayName: Run self-contained build (binaries V1, where the binaries are all bundled together)
+      timeoutInMinutes: 120
+      cancelTimeoutInMinutes: 1
+      pool:
+        name: 'VSEngSS-MicroBuild2022-1ES'
+        demands:
+        - msbuild
+        - visualstudio
+        - DotNetFramework
+      steps:
+      - checkout: self
+        clean: true
+        fetchTags: false
+        persistCredentials: True
+      - task: PowerShell@2
+        displayName: Set staging/prod build vars for signing and telemetry copy
+        enabled: True
+        inputs:
+          targetType: inline
+          script: >-
+            if ($env:ForceStagingBuild -eq "true" -And $env:ForceProductionBuild -eq "true") {
+              Write-Host "You can't do a Staging and Production build at the same time... Duh...."
+              exit 1
+            }
+    
+    
+            $branchName = $env:BUILD_SOURCEBRANCH
+    
+            if ($branchName -eq "refs/heads/main") {
+                Write-Host "##vso[task.setvariable variable=TelemetryType]"{{ parameters.TelemetryType }}
+                Write-Host "Done setting the sign type and telemetry key instance for main branch"
+            }
+    
+    
+            Write-Host "Disabling NuGet package signing because it doesn't work, and we don't publish public NuGet packages"
+    
+            Write-Host "##vso[task.setvariable variable=MicroBuild_NuPkgSigningEnabled]false"
+      - task: MicroBuildSigningPlugin@3
+        name: ''
+        displayName: Install Signing Plugin
+        enabled: True
+        inputs:
+          signType: ${{ parameters.SignTypeToUse }}
+          zipSources: false
+      - task: MicroBuildLocalizationPlugin@3
+        displayName: 'Install Localization Plugin'
+        enabled: True
+      - task: UseDotNet@2
+        displayName: Use .NET Core SDK 6.0.x
+        enabled: True
+        inputs:
+          version: $(BuildParameters.dotnetversion)
+          installationPath: $(Agent.TempDirectory)/dotnet
+      - task: DotNetCoreCLI@2
+        displayName: restore EndpointManager (Windows) (to download runtime pack)
+        enabled: True
+        inputs:
+          command: restore
+          projects: src\endpointmanager\endpointmanager.csproj
+          restoreArguments: -r win-x64
+          selectOrConfig: config
+          nugetConfigPath: src/nuget.config
+          externalEndpoints: dba0ba50-2d4e-4f12-9f5a-42a638da803b
+      - task: NuGetToolInstaller@1
+        name: ''
+        displayName: Use NuGet 5.9.x
+        enabled: True
+        inputs:
+          versionSpec: $(BuildParameters.nugetversion)
+      - task: NuGetCommand@2
+        name: ''
+        displayName: NuGet restore client.sln
+        enabled: True
+        inputs:
+          solution: src/client.sln
+          selectOrConfig: config
+          feedRestore: fc5819b5-ed1c-4a51-9766-a55ddb558d72
+          nugetConfigPath: src/nuget.config
+          externalEndpoints: dba0ba50-2d4e-4f12-9f5a-42a638da803b
+          verbosityRestore: Normal
+          searchPatternPush: $(Build.ArtifactStagingDirectory)/*.nupkg
+      - task: VSBuild@1
+        name: ''
+        displayName: Build client.sln for Loc and Tests
+        condition: and(succeeded(), eq(variables.RunTests, 'true'))
+        enabled: True
+        inputs:
+          solution: src/client.sln
+          msbuildArgs: -p:Localize=true -p:ConsumeEndpointManager=false
+          configuration: ${{ parameters.BuildConfiguration }}
+      - task: VSTest@2
+        displayName: Run Unit Tests
+        condition: and(succeeded(), eq(variables.RunTests, 'true'))
+        enabled: True
+        inputs:
+          testAssemblyVer2: '**\bin\${{ parameters.BuildConfiguration }}\*\*Tests.dll'
+          runSettingsFile: tests/unittests/dotnetcore.runsettings
+          runInParallel: true
+          codeCoverageEnabled: True
+          testRunTitle: Unit Tests
+          failOnMinTestsNotRun: true
+          rerunFailedTests: true
+      - task: CopyFiles@2
+        displayName: Collect Loc files
+        condition: and(succeeded(), eq(variables.RunTests, 'true'))
+        enabled: True
+        inputs:
+          Contents: >-
+            src/*/bin/*/*/localize/**/*
+    
+            src/*/bin/**/*.lce
+    
+            src/dsc/bin/*/*/dsc.dll
+    
+            src/endpointmanager/bin/*/*/endpointmanager.dll
+    
+            src/common/bin/*/*/Microsoft.BridgeToKubernetes.Common.dll
+    
+            src/library/bin/*/*/Microsoft.BridgeToKubernetes.Library.dll
+          TargetFolder: $(Build.ArtifactStagingDirectory)/Loc
+          OverWrite: true
+      - task: PublishBuildArtifacts@1
+        displayName: 'Publish Artifact: Loc'
+        condition: and(succeeded(), eq(variables.RunTests, 'true'))
+        enabled: True
+        inputs:
+          PathtoPublish: $(Build.ArtifactStagingDirectory)/Loc
+          ArtifactName: Loc
+          TargetPath: '\\my\share\$(Build.DefinitionName)\$(Build.BuildNumber)'
+      - task: DotNetCoreCLI@2
+        displayName: publish DSC (Windows)
+        enabled: True
+        inputs:
+          command: publish
+          publishWebProjects: false
+          projects: src\dsc\dsc.csproj
+          arguments: -c ${{ parameters.BuildConfiguration }} -r win-x64 --no-restore --self-contained true --verbosity detailed
+          zipAfterPublish: false
+          modifyOutputPath: false
+          selectOrConfig: config
+      - task: DotNetCoreCLI@2
+        displayName: publish EndpointManagerLauncher(Windows)
+        enabled: True
+        inputs:
+          command: publish
+          publishWebProjects: false
+          projects: src\EndpointManagerLauncher\endpointmanagerlauncher.csproj
+          arguments: -c ${{ parameters.BuildConfiguration }} -r win-x64 --no-restore --verbosity detailed
+          zipAfterPublish: false
+          modifyOutputPath: false
+          selectOrConfig: config
+      - task: CopyFiles@2
+        displayName: Copy EndpointManager Launcher to dsc folder
+        enabled: True
+        inputs:
+          SourceFolder: src/EndpointManagerLauncher/bin/${{ parameters.BuildConfiguration }}/net6.0/win-x64/publish/
+          Contents: >-
+            **/*
+    
+            !**/*.pdb
+          TargetFolder: src/dsc/bin/${{ parameters.BuildConfiguration }}/net6.0/win-x64/publish/EndpointManagerLauncher
+          OverWrite: true
+      - task: DotNetCoreCLI@2
+        displayName: publish DSC (OSX)
+        enabled: True
+        inputs:
+          command: publish
+          publishWebProjects: false
+          projects: src\dsc\dsc.csproj
+          arguments: -c ${{ parameters.BuildConfiguration }} -r osx-x64 --no-restore --self-contained true --verbosity detailed
+          zipAfterPublish: false
+          modifyOutputPath: false
+          selectOrConfig: config
+      - task: DotNetCoreCLI@2
+        displayName: publish DSC (Linux)
+        enabled: True
+        inputs:
+          command: publish
+          publishWebProjects: false
+          projects: src\dsc\dsc.csproj
+          arguments: -c ${{ parameters.BuildConfiguration }} -r linux-x64 --no-restore --self-contained true --verbosity detailed
+          zipAfterPublish: false
+          modifyOutputPath: false
+          selectOrConfig: config
+      - task: PowerShell@2
+        displayName: Download kubectl
+        continueOnError: True
+        enabled: True
+        inputs:
+          targetType: inline
+          script: >
+            New-Item -Path './src/dsc/bin/${{ parameters.BuildConfiguration }}/net6.0/win-x64/publish/kubectl' -ItemType Directory
+    
+            New-Item -Path './src/dsc/bin/${{ parameters.BuildConfiguration }}/net6.0/win-x64/publish/kubectl/win' -ItemType Directory
+    
+            curl https://dl.k8s.io/release/v1.21.2/bin/windows/amd64/kubectl.exe -OutFile ./src/dsc/bin/${{ parameters.BuildConfiguration }}/net6.0/win-x64/publish/kubectl/win/kubectl.exe
+    
+    
+            New-Item -Path './src/dsc/bin/${{ parameters.BuildConfiguration }}/net6.0/osx-x64/publish/kubectl' -ItemType Directory
+    
+            New-Item -Path './src/dsc/bin/${{ parameters.BuildConfiguration }}/net6.0/osx-x64/publish/kubectl/osx' -ItemType Directory
+    
+            curl https://dl.k8s.io/release/v1.21.2/bin/darwin/amd64/kubectl  -OutFile ./src/dsc/bin/${{ parameters.BuildConfiguration }}/net6.0/osx-x64/publish/kubectl/osx/kubectl
+    
+    
+            New-Item -Path './src/dsc/bin/${{ parameters.BuildConfiguration }}/net6.0/linux-x64/publish/kubectl' -ItemType Directory
+    
+            New-Item -Path './src/dsc/bin/${{ parameters.BuildConfiguration }}/net6.0/linux-x64/publish/kubectl/linux' -ItemType Directory
+    
+            curl https://dl.k8s.io/release/v1.21.2/bin/linux/amd64/kubectl  -OutFile ./src/dsc/bin/${{ parameters.BuildConfiguration }}/net6.0/linux-x64/publish/kubectl/linux/kubectl
+      - task: VSBuild@1
+        name: ''
+        displayName: Sign Files
+        enabled: True
+        inputs:
+          solution: src/client.signproj
+          msbuildArgs: /t:SignFiles /p:SignType=${{ parameters.SignTypeToUse }}
+          configuration: '${{ parameters.BuildConfiguration }} '
+      - task: CopyFiles@2
+        displayName: Collect files for .zip (Windows)
+        enabled: True
+        inputs:
+          SourceFolder: src/dsc/bin/${{ parameters.BuildConfiguration }}/net6.0/win-x64/publish
+          Contents: >-
+            **/*
+    
+            !**/*.pdb
+    
+            !**/*.xml
+    
+            !**/*.nuspec
+    
+            !**/cs/*
+    
+            !**/de/*
+    
+            !**/es/*
+    
+            !**/fr/*
+    
+            !**/it/*
+    
+            !**/ja/*
+    
+            !**/ko/*
+    
+            !**/pl/*
+    
+            !**/pt-BR/*
+    
+            !**/ru/*
+    
+            !**/tr/*
+    
+            !**/zh-Hans/*
+    
+            !**/zh-Hant/*
+          TargetFolder: $(Agent.TempDirectory)/zip/win
+      - task: CopyFiles@2
+        displayName: Collect files for .zip (OSX)
+        enabled: True
+        inputs:
+          SourceFolder: src/dsc/bin/${{ parameters.BuildConfiguration }}/net6.0/osx-x64/publish
+          Contents: >-
+            **/*
+    
+            src/resources/license.rtf
+    
+            src/vscode/ThirdPartyNotices.txt
+    
+            !**/*.pdb
+    
+            !**/*.xml
+    
+            !**/*.nuspec
+    
+            !**/cs/*
+    
+            !**/de/*
+    
+            !**/es/*
+    
+            !**/fr/*
+    
+            !**/it/*
+    
+            !**/ja/*
+    
+            !**/ko/*
+    
+            !**/pl/*
+    
+            !**/pt-BR/*
+    
+            !**/ru/*
+    
+            !**/tr/*
+    
+            !**/zh-Hans/*
+    
+            !**/zh-Hant/*
+          TargetFolder: $(Agent.TempDirectory)/zip/osx
+      - task: CopyFiles@2
+        displayName: Collect files for .zip (Linux)
+        enabled: True
+        inputs:
+          SourceFolder: src/dsc/bin/${{ parameters.BuildConfiguration }}/net6.0/linux-x64/publish
+          Contents: >-
+            **/*
+    
+            src/resources/license.rtf
+    
+            src/vscode/ThirdPartyNotices.txt
+    
+            !**/*.pdb
+    
+            !**/*.xml
+    
+            !**/*.nuspec
+    
+            !**/cs/*
+    
+            !**/de/*
+    
+            !**/es/*
+    
+            !**/fr/*
+    
+            !**/it/*
+    
+            !**/ja/*
+    
+            !**/ko/*
+    
+            !**/pl/*
+    
+            !**/pt-BR/*
+    
+            !**/ru/*
+    
+            !**/tr/*
+    
+            !**/zh-Hans/*
+    
+            !**/zh-Hant/*
+          TargetFolder: $(Agent.TempDirectory)/zip/linux
+      - task: ArchiveFiles@2
+        displayName: Create .zip file (Windows)
+        enabled: True
+        inputs:
+          rootFolderOrFile: $(Agent.TempDirectory)/zip/win
+          includeRootFolder: false
+          sevenZipCompression: 5
+          archiveFile: $(Build.ArtifactStagingDirectory)/zip/lpk-win.zip
+      - task: ArchiveFiles@2
+        displayName: Create .zip file (OSX)
+        enabled: True
+        inputs:
+          rootFolderOrFile: $(Agent.TempDirectory)/zip/osx
+          includeRootFolder: false
+          sevenZipCompression: 5
+          archiveFile: $(Build.ArtifactStagingDirectory)/zip/lpk-osx.zip
+      - task: ArchiveFiles@2
+        displayName: Create .zip file (Linux)
+        enabled: True
+        inputs:
+          rootFolderOrFile: $(Agent.TempDirectory)/zip/linux
+          includeRootFolder: false
+          sevenZipCompression: 5
+          archiveFile: $(Build.ArtifactStagingDirectory)/zip/lpk-linux.zip
+      - task: PowerShell@2
+        displayName: Generate lks.json for .zip files
+        enabled: True
+        inputs:
+          targetType: inline
+          script: >-
+            $ZipHost = "mindaromaster.blob.core.windows.net"
+    
+            $BlobUrl = "https://$ZipHost/zip/1.0.$env:BUILD_BUILDNUMBER"
+    
+            $ZipDir = "$env:BUILD_ARTIFACTSTAGINGDIRECTORY/zip"
+    
+            $Win = @{ url="$BlobUrl/lpk-win.zip"; sha256hash="$((Get-FileHash $ZipDir\lpk-win.zip).Hash)" }
+    
+            $OSX = @{ url="$BlobUrl/lpk-osx.zip"; sha256hash="$((Get-FileHash $ZipDir\lpk-osx.zip).Hash)" }
+    
+            $Linux = @{ url="$BlobUrl/lpk-linux.zip"; sha256hash="$((Get-FileHash $ZipDir\lpk-linux.zip).Hash)" }
+    
+            $Json = @{ version="1.0.$env:BUILD_BUILDNUMBER"; win = $Win; osx = $OSX; linux = $Linux } | ConvertTo-Json
+    
+            $Json | Out-File -FilePath $ZipDir/lks.json -Encoding ascii
+    
+            New-Item -ItemType directory -Path $ZipDir/1.0.$env:BUILD_BUILDNUMBER
+    
+            $Json | Out-File -FilePath $ZipDir/1.0.$env:BUILD_BUILDNUMBER/lks.json -Encoding ascii
+    
+            Write-Host $Json
+      - task: ManifestGeneratorTask@0
+        displayName: Manifest Generator for zip
+        enabled: True
+        inputs:
+          BuildDropPath: $(Build.ArtifactStagingDirectory)/zip
+      - task: PublishBuildArtifacts@1
+        displayName: 'Publish Artifact: zip'
+        enabled: True
+        inputs:
+          PathtoPublish: $(Build.ArtifactStagingDirectory)/zip
+          ArtifactName: zip
+          TargetPath: '\\my\share\$(Build.DefinitionName)\$(Build.BuildNumber)'
+      - task: DotNetCoreCLI@2
+        displayName: 'dotnet pack CLI NuGet (Windows)'
+        inputs:
+          command: pack
+          feedsToUse: config
+          packagesToPack: src/dsc/dsc.csproj
+          packDirectory: '$(Build.ArtifactStagingDirectory)/nuget'
+          nobuild: true
+          buildProperties: 'NuspecFile=bin\${{ parameters.BuildConfiguration }}\net6.0\win-x64\publish\dsc.nuspec'
+      - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
+        displayName: 'Manifest Generator for nuget'
+        inputs:
+          BuildDropPath: '$(Build.ArtifactStagingDirectory)/nuget'
+      - task: PublishBuildArtifacts@1
+        displayName: 'Publish Artifact: nuget'
+        inputs:
+          PathtoPublish: '$(Build.ArtifactStagingDirectory)/nuget'
+          ArtifactName: nuget
+      - task: CopyFiles@2
+        displayName: Collect Build Symbols - dsc
+        enabled: True
+        inputs:
+          SourceFolder: src/dsc/bin/${{ parameters.BuildConfiguration }}/net6.0
+          Contents: >-
+            */publish/dsc.?(pdb|exe|dll|)
+    
+            */publish/Microsoft.BridgeToKubernetes.*.@(pdb|exe|dll|)
+    
+            */publish/EndpointManager/EndpointManager.?(pdb|exe|dll|)
+    
+            */publish/EndpointManager/Microsoft.BridgeToKubernetes.*.@(pdb|exe|dll|)
+          TargetFolder: $(Build.ArtifactStagingDirectory)/symbols
+          OverWrite: true
+      - task: PublishSymbols@2
+        displayName: Enable Source Server
+        condition: and(succeeded(), eq(variables.RunTests, 'true'))
+        enabled: True
+        inputs:
+          SymbolsFolder: $(Build.ArtifactStagingDirectory)/symbols
+          SearchPattern: '**/*.pdb'
+          SymbolServerType: TeamServices
+      - task: CopyFiles@2
+        displayName: Copy buildWindowsPDBs.ps1 to artifact directory
+        enabled: True
+        inputs:
+          SourceFolder: build
+          Contents: buildWindowsPDBs.ps1
+          TargetFolder: $(Build.ArtifactStagingDirectory)/symbols/
+          OverWrite: true
+      - task: PublishBuildArtifacts@1
+        displayName: 'Publish Artifact: symbols'
+        condition: and(succeeded(), eq(variables.RunTests, 'true'))
+        enabled: True
+        inputs:
+          PathtoPublish: $(Build.ArtifactStagingDirectory)/symbols
+          ArtifactName: symbols
+          TargetPath: '\\my\share\$(Build.DefinitionName)\$(Build.BuildNumber)'
+      - task: tagBuildOrRelease@0
+        displayName: Tag BuildConfiguration
+        enabled: True
+        inputs:
+          tags: 'BuildConfiguration: ${{ parameters.BuildConfiguration }}'
+    - job: Phase_2
+      displayName: Run NON self-contained build (binaries V2, where the binaries are downloaded in parallel)
+      timeoutInMinutes: 120
+      cancelTimeoutInMinutes: 1
+      pool:
+        name: 'VSEngSS-MicroBuild2022-1ES'
+        demands:
+        - msbuild
+        - visualstudio
+        - vstest
+      steps:
+      - checkout: self
+        clean: true
+        fetchTags: false
+        persistCredentials: True
+      - task: PowerShell@2
+        displayName: Set staging/prod build vars for signing and telemetry
+        inputs:
+          targetType: inline
+          script: >-
+            $branchName = $env:BUILD_SOURCEBRANCH
+    
+            if ($branchName -eq "refs/heads/main") {
+                Write-Host "##vso[task.setvariable variable=TelemetryType]"{{ parameters.TelemetryType }}
+                Write-Host "Done setting the sign type and telemetry key instance for staging branch"
+            }
+    
+            Write-Host "Disabling NuGet package signing because it doesn't work, and we don't publish public NuGet packages"
+    
+            Write-Host "##vso[task.setvariable variable=MicroBuild_NuPkgSigningEnabled]false"
+      - task: MicroBuildSigningPlugin@3
+        displayName: Install Signing Plugin
+        enabled: True
+        inputs:
+          signType: ${{ parameters.SignTypeToUse }}
+          zipSources: false
+      - task: MicroBuildLocalizationPlugin@3
+        displayName: Install Localization Plugin
+      - task: UseDotNet@2
+        displayName: Use .NET Core SDK 6.0.X
+        inputs:
+          version: 6.0.306
+          installationPath: $(Agent.TempDirectory)/dotnet
+      - task: DotNetCoreCLI@2
+        displayName: restore EndpointManager (Windows) (to download runtime pack)
+        inputs:
+          command: restore
+          projects: src\endpointmanager\endpointmanager.csproj
+          restoreArguments: -r win-x64
+          selectOrConfig: config
+          nugetConfigPath: src/nuget.config
+          externalEndpoints: dba0ba50-2d4e-4f12-9f5a-42a638da803b
+      - task: NuGetToolInstaller@1
+        displayName: Use NuGet 6.1.x
+        inputs:
+          versionSpec: 6.1.x
+      - task: NuGetCommand@2
+        displayName: NuGet restore client.sln
+        inputs:
+          solution: src/client.sln
+          selectOrConfig: config
+          nugetConfigPath: src/nuget.config
+          externalEndpoints: dba0ba50-2d4e-4f12-9f5a-42a638da803b
+      - task: DotNetCoreCLI@2
+        displayName: publish DSC (Windows)
+        inputs:
+          command: publish
+          publishWebProjects: false
+          projects: src\dsc\dsc.csproj
+          arguments: -c ${{ parameters.BuildConfiguration }} -r win-x64 --self-contained false --no-restore --verbosity detailed
+          zipAfterPublish: false
+          modifyOutputPath: false
+      - task: CmdLine@2
+        displayName: Build EndpointManager Launcher using .Net 5
+        inputs:
+          script: >-
+            echo "Publishing EndpointManager Launcher..."
+    
+            "C:\Program Files\dotnet\dotnet.exe" publish src\EndpointManagerLauncher\endpointmanagerlauncher.csproj -r win-x64 -c {{ parameters.BuildConfiguration }} --no-restore
+    
+            echo "Done publishing EndpointManager Launcher..."
+      - task: CopyFiles@2
+        displayName: Copy EndpointManager Launcher to dsc folder
+        inputs:
+          SourceFolder: src/EndpointManagerLauncher/bin/${{ parameters.BuildConfiguration }}/net6.0/win-x64/publish/
+          Contents: >-
+            **/*
+    
+            !**/*.pdb
+          TargetFolder: src/dsc/bin/${{ parameters.BuildConfiguration }}/net6.0/win-x64/publish/EndpointManagerLauncher
+      - task: DotNetCoreCLI@2
+        displayName: publish DSC (OSX)
+        inputs:
+          command: publish
+          publishWebProjects: false
+          projects: src\dsc\dsc.csproj
+          arguments: -c ${{ parameters.BuildConfiguration }} -r osx-x64 --no-restore --self-contained false --verbosity detailed
+          zipAfterPublish: false
+          modifyOutputPath: false
+      - task: DotNetCoreCLI@2
+        displayName: publish DSC (Linux)
+        inputs:
+          command: publish
+          publishWebProjects: false
+          projects: src\dsc\dsc.csproj
+          arguments: -c ${{ parameters.BuildConfiguration }} -r linux-x64 --no-restore --self-contained false --verbosity detailed
+          zipAfterPublish: false
+          modifyOutputPath: false
+      - task: PowerShell@2
+        displayName: Download kubectl
+        continueOnError: True
+        inputs:
+          targetType: inline
+          script: >
+            New-Item -Path '$(Build.SourcesDirectory)/src/dsc/bin/${{ parameters.BuildConfiguration }}/net6.0/win-x64/publish/kubectl' -ItemType Directory
+    
+            New-Item -Path '$(Build.SourcesDirectory)/src/dsc/bin/${{ parameters.BuildConfiguration }}/net6.0/win-x64/publish/kubectl/win' -ItemType Directory
+    
+            curl https://dl.k8s.io/release/v1.21.2/bin/windows/amd64/kubectl.exe -OutFile $(Build.SourcesDirectory)/src/dsc/bin/${{ parameters.BuildConfiguration }}/net6.0/win-x64/publish/kubectl/win/kubectl.exe
+    
+    
+            New-Item -Path '$(Build.SourcesDirectory)/src/dsc/bin/${{ parameters.BuildConfiguration }}/net6.0/osx-x64/publish/kubectl' -ItemType Directory
+    
+            New-Item -Path '$(Build.SourcesDirectory)/src/dsc/bin/${{ parameters.BuildConfiguration }}/net6.0/osx-x64/publish/kubectl/osx' -ItemType Directory
+    
+            curl https://dl.k8s.io/release/v1.21.2/bin/darwin/amd64/kubectl  -OutFile $(Build.SourcesDirectory)/src/dsc/bin/${{ parameters.BuildConfiguration }}/net6.0/osx-x64/publish/kubectl/osx/kubectl
+    
+    
+            New-Item -Path '$(Build.SourcesDirectory)/src/dsc/bin/${{ parameters.BuildConfiguration }}/net6.0/linux-x64/publish/kubectl' -ItemType Directory
+    
+            New-Item -Path '$(Build.SourcesDirectory)/src/dsc/bin/${{ parameters.BuildConfiguration }}/net6.0/linux-x64/publish/kubectl/linux' -ItemType Directory
+    
+            curl https://dl.k8s.io/release/v1.21.2/bin/linux/amd64/kubectl  -OutFile $(Build.SourcesDirectory)/src/dsc/bin/${{ parameters.BuildConfiguration }}/net6.0/linux-x64/publish/kubectl/linux/kubectl
+      - task: VSBuild@1
+        displayName: Sign Files
+        enabled: True
+        inputs:
+          solution: src/client.signproj
+          msbuildArgs: /t:SignFiles /p:SignType=${{ parameters.SignTypeToUse }}
+          configuration: '${{ parameters.BuildConfiguration }} '
+      - task: CopyFiles@2
+        displayName: Collect files for .zip (Windows)
+        inputs:
+          SourceFolder: src/dsc/bin/${{ parameters.BuildConfiguration }}/net6.0/win-x64/publish
+          Contents: >-
+            **/*
+    
+            !**/*.pdb
+    
+            !**/*.xml
+    
+            !**/*.nuspec
+    
+            !**/cs/*
+    
+            !**/de/*
+    
+            !**/es/*
+    
+            !**/fr/*
+    
+            !**/it/*
+    
+            !**/ja/*
+    
+            !**/ko/*
+    
+            !**/pl/*
+    
+            !**/pt-BR/*
+    
+            !**/ru/*
+    
+            !**/tr/*
+    
+            !**/zh-Hans/*
+    
+            !**/zh-Hant/*
+          TargetFolder: $(Agent.TempDirectory)/zip/win
+      - task: CopyFiles@2
+        displayName: Collect files for .zip (OSX)
+        inputs:
+          SourceFolder: src/dsc/bin/${{ parameters.BuildConfiguration }}/net6.0/osx-x64/publish
+          Contents: >-
+            **/*
+    
+            src/resources/license.rtf
+    
+            src/vscode/ThirdPartyNotices.txt
+    
+            !**/*.pdb
+    
+            !**/*.xml
+    
+            !**/*.nuspec
+    
+            !**/cs/*
+    
+            !**/de/*
+    
+            !**/es/*
+    
+            !**/fr/*
+    
+            !**/it/*
+    
+            !**/ja/*
+    
+            !**/ko/*
+    
+            !**/pl/*
+    
+            !**/pt-BR/*
+    
+            !**/ru/*
+    
+            !**/tr/*
+    
+            !**/zh-Hans/*
+    
+            !**/zh-Hant/*
+          TargetFolder: $(Agent.TempDirectory)/zip/osx
+      - task: CopyFiles@2
+        displayName: Collect files for .zip (Linux)
+        inputs:
+          SourceFolder: src/dsc/bin/${{ parameters.BuildConfiguration }}/net6.0/linux-x64/publish
+          Contents: >-
+            **/*
+    
+            src/resources/license.rtf
+    
+            src/vscode/ThirdPartyNotices.txt
+    
+            !**/*.pdb
+    
+            !**/*.xml
+    
+            !**/*.nuspec
+    
+            !**/cs/*
+    
+            !**/de/*
+    
+            !**/es/*
+    
+            !**/fr/*
+    
+            !**/it/*
+    
+            !**/ja/*
+    
+            !**/ko/*
+    
+            !**/pl/*
+    
+            !**/pt-BR/*
+    
+            !**/ru/*
+    
+            !**/tr/*
+    
+            !**/zh-Hans/*
+    
+            !**/zh-Hant/*
+          TargetFolder: $(Agent.TempDirectory)/zip/linux
+      - task: ArchiveFiles@2
+        displayName: Create .zip file (Windows)
+        inputs:
+          rootFolderOrFile: $(Agent.TempDirectory)/zip/win
+          includeRootFolder: false
+          sevenZipCompression: 5
+          archiveFile: $(Build.ArtifactStagingDirectory)/zip/lpk-win.zip
+      - task: ArchiveFiles@2
+        displayName: Create .zip file (OSX)
+        inputs:
+          rootFolderOrFile: $(Agent.TempDirectory)/zip/osx
+          includeRootFolder: false
+          sevenZipCompression: 5
+          archiveFile: $(Build.ArtifactStagingDirectory)/zip/lpk-osx.zip
+      - task: ArchiveFiles@2
+        displayName: Create .zip file (Linux)
+        inputs:
+          rootFolderOrFile: $(Agent.TempDirectory)/zip/linux
+          includeRootFolder: false
+          sevenZipCompression: 5
+          archiveFile: $(Build.ArtifactStagingDirectory)/zip/lpk-linux.zip
+      - task: PowerShell@2
+        displayName: Generate lks.json for .zip files
+        inputs:
+          targetType: inline
+          script: >
+            $ZipHost = "mindaromaster.blob.core.windows.net"
+    
+            $BlobUrl = "https://$ZipHost/zipv2/1.0.$env:BUILD_BUILDNUMBER"
+    
+            $BlobLKSUrl = "https://$ZipHost/zipv2/LKS"
+    
+            $ZipDir = "$env:BUILD_ARTIFACTSTAGINGDIRECTORY/zip"
+    
+            # CLI binaries
+    
+            $Cli_Win = @{ url="$BlobUrl/lpk-win.zip"; sha256hash="$((Get-FileHash $ZipDir\lpk-win.zip).Hash)" }
+    
+            $Cli_Osx = @{ url="$BlobUrl/lpk-osx.zip"; sha256hash="$((Get-FileHash $ZipDir\lpk-osx.zip).Hash)" }
+    
+            $Cli_Linux = @{ url="$BlobUrl/lpk-linux.zip"; sha256hash="$((Get-FileHash $ZipDir\lpk-linux.zip).Hash)" }
+    
+            # Kubectl binaries
+    
+            $Kubectl_Win = @{ url="$BlobLKSUrl/kubectl-win.zip"; sha256hash="5490F9B60E4C2C4229CA00FBFA946AE65655F0739BE9714C6A0A0FB7BE2A6F2C" }
+    
+            $Kubectl_Osx = @{ url="$BlobLKSUrl/kubectl-osx.zip"; sha256hash="D24EAFEC39EB2393DBA0088B762953BEDCC04156AC9E324FA290476BD3C888B9" }
+    
+            $Kubectl_Linux = @{ url="$BlobLKSUrl/kubectl-linux.zip"; sha256hash="01B76D4E4A9081452932F27C767C9D8F3507C8AD3CC9269CEB16729F4D0ED900" }
+    
+            #dotnet runtime binaries
+    
+            $Dotnet_Win = @{ url="$BlobLKSUrl/dotnetruntime-win.zip"; sha256hash="0FCA9F2AB829C85615007EA646CF436D2E90C9A4095C84C2F9EB3EC0754468A8" }
+    
+            $Dotnet_Osx = @{ url="$BlobLKSUrl/dotnetruntime-osx.zip"; sha256hash="D25F8BB708C364678AAA0F3798F5EADD1BE46800376F15D2F12C785C74AF8443" }
+    
+            $Dotnet_Linux = @{ url="$BlobLKSUrl/dotnetruntime-linux.zip"; sha256hash="801D9D251D07B9A88195450FCBFD70C7507CEEEF05D5F0E88CC14CEBFCC10F4B" }
+    
+            # Win Json
+    
+            $Win = @{ dotnetruntime = $Dotnet_Win; kubectl = $Kubectl_Win; bridge = $Cli_Win }
+    
+            # OSX Json
+    
+            $OSX = @{ dotnetruntime = $Dotnet_Osx; kubectl = $Kubectl_Osx; bridge = $Cli_Osx }
+    
+            # Linux Json
+    
+            $Linux = @{ dotnetruntime = $Dotnet_Linux; kubectl = $Kubectl_Linux; bridge = $Cli_Linux }
+    
+            $Json = @{ version="1.0.$env:BUILD_BUILDNUMBER"; win = $Win; osx = $OSX; linux = $Linux } | ConvertTo-Json
+    
+            $Json | Out-File -FilePath $ZipDir/lks.json -Encoding ascii
+    
+            New-Item -ItemType directory -Path $ZipDir/1.0.$env:BUILD_BUILDNUMBER
+    
+            $Json | Out-File -FilePath $ZipDir/1.0.$env:BUILD_BUILDNUMBER/lks.json -Encoding ascii
+    
+            Write-Host $Json
+      - task: ManifestGeneratorTask@0
+        displayName: Manifest Generator for zip
+        inputs:
+          BuildDropPath: $(Build.ArtifactStagingDirectory)/zip/
+      - task: PublishBuildArtifacts@1
+        displayName: Generate lks.json for .zip files
+        inputs:
+          PathtoPublish: $(Build.ArtifactStagingDirectory)/zip
+          ArtifactName: zipv2
+    ...
+    

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -599,17 +599,20 @@
           arguments: -c ${{ parameters.BuildConfiguration }} -r win-x64 --self-contained false --no-restore --verbosity detailed
           zipAfterPublish: false
           modifyOutputPath: false
-      - task: CmdLine@2
-        displayName: Build EndpointManager Launcher using .Net 5
+      - task: DotNetCoreCLI@2
+        displayName: publish EndpointManagerLauncher(Windows)
+        enabled: True
         inputs:
-          script: >-
-            echo "Publishing EndpointManager Launcher..."
-    
-            "C:\Program Files\dotnet\dotnet.exe" publish src\EndpointManagerLauncher\endpointmanagerlauncher.csproj -r win-x64 -c {{ parameters.BuildConfiguration }} --no-restore
-    
-            echo "Done publishing EndpointManager Launcher..."
+          command: publish
+          publishWebProjects: false
+          projects: src\EndpointManagerLauncher\endpointmanagerlauncher.csproj
+          arguments: -c ${{ parameters.BuildConfiguration }} -r win-x64 --no-restore --verbosity detailed
+          zipAfterPublish: false
+          modifyOutputPath: false
+          selectOrConfig: config
       - task: CopyFiles@2
         displayName: Copy EndpointManager Launcher to dsc folder
+        enabled: True
         inputs:
           SourceFolder: src/EndpointManagerLauncher/bin/${{ parameters.BuildConfiguration }}/net6.0/win-x64/publish/
           Contents: >-
@@ -617,6 +620,7 @@
     
             !**/*.pdb
           TargetFolder: src/dsc/bin/${{ parameters.BuildConfiguration }}/net6.0/win-x64/publish/EndpointManagerLauncher
+          OverWrite: true
       - task: DotNetCoreCLI@2
         displayName: publish DSC (OSX)
         inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -33,13 +33,6 @@ parameters:
     values:
     - Release
     - Debug
-  - name: RunTests
-    displayName: Run unit test cases
-    type: boolean
-    default: true
-    values:
-    - true
-    - false
 variables:
 - name: BuildParameters.dotnetversion
   value: 6.0.x
@@ -47,6 +40,8 @@ variables:
   value: 5.9.x
 - name: TeamName
   value: Mindaro
+- name: RunTests
+  value: True
 
 trigger:
   branches:
@@ -145,7 +140,7 @@ jobs:
   - task: VSBuild@1
     name: ''
     displayName: Build client.sln for Loc and Tests
-    condition: and(succeeded(), eq(parameters.RunTests, 'true'))
+    condition: and(succeeded(), eq(variables.RunTests, 'true'))
     enabled: True
     inputs:
       solution: src/client.sln
@@ -153,7 +148,7 @@ jobs:
       configuration: ${{ parameters.BuildConfiguration }}
   - task: VSTest@2
     displayName: Run Unit Tests
-    condition: and(succeeded(), eq(parameters.RunTests, 'true'))
+    condition: and(succeeded(), eq(variables.RunTests, 'true'))
     enabled: True
     inputs:
       testAssemblyVer2: '**\bin\${{ parameters.BuildConfiguration }}\*\*Tests.dll'
@@ -165,7 +160,7 @@ jobs:
       rerunFailedTests: true
   - task: CopyFiles@2
     displayName: Collect Loc files
-    condition: and(succeeded(), eq(parameters.RunTests, 'true'))
+    condition: and(succeeded(), eq(variables.RunTests, 'true'))
     enabled: True
     inputs:
       Contents: >-
@@ -184,7 +179,7 @@ jobs:
       OverWrite: true
   - task: PublishBuildArtifacts@1
     displayName: 'Publish Artifact: Loc'
-    condition: and(succeeded(), eq(parameters.RunTests, 'true'))
+    condition: and(succeeded(), eq(variables.RunTests, 'true'))
     enabled: True
     inputs:
       PathtoPublish: $(Build.ArtifactStagingDirectory)/Loc
@@ -505,7 +500,7 @@ jobs:
       OverWrite: true
   - task: PublishSymbols@2
     displayName: Enable Source Server
-    condition: and(succeeded(), eq(parameters.RunTests, 'true'))
+    condition: and(succeeded(), eq(variables.RunTests, 'true'))
     enabled: True
     inputs:
       SymbolsFolder: $(Build.ArtifactStagingDirectory)/symbols
@@ -521,7 +516,7 @@ jobs:
       OverWrite: true
   - task: PublishBuildArtifacts@1
     displayName: 'Publish Artifact: symbols'
-    condition: and(succeeded(), eq(parameters.RunTests, 'true'))
+    condition: and(succeeded(), eq(variables.RunTests, 'true'))
     enabled: True
     inputs:
       PathtoPublish: $(Build.ArtifactStagingDirectory)/symbols

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -21,19 +21,34 @@ parameters:
     - none
     - test
     - real
+  - name: TelemetryType
+    displayName: Telemetry Type so that correct application insights key is selected
+    default: 'TELEMETRY_DEVELOPMENT'
+    values:
+    - TELEMETRY_DEVELOPMENT
+    - TELEMETRY_STAGING
+    - TELEMETRY_PRODUCTION
+  - name: BuildConfiguration
+    displayName: BuildConfiguration to be used
+    default: 'Release'
+    values:
+    - Release
+    - Debug
+  - name: RunTests
+    displayName: Run unit test cases
+    type: boolean
+    default: true
+    values:
+    - true
+    - false
 variables:
 - name: BuildParameters.dotnetversion
   value: 6.0.x
 - name: BuildParameters.nugetversion
   value: 5.9.x
-- name: BuildConfiguration
-  value: Release
-- name: RunTests
-  value: true
 - name: TeamName
   value: Mindaro
-- name: TelemetryType
-  value: TELEMETRY_DEVELOPMENT
+
 trigger:
   branches:
     include:
@@ -76,7 +91,7 @@ jobs:
         $branchName = $env:BUILD_SOURCEBRANCH
 
         if ($branchName -eq "refs/heads/main") {
-            Write-Host "##vso[task.setvariable variable=TelemetryType]TELEMETRY_PRODUCTION"
+            Write-Host "##vso[task.setvariable variable=TelemetryType]"{{ parameters.TelemetryType }}
             Write-Host "Done setting the sign type and telemetry key instance for main branch"
         }
 
@@ -87,6 +102,7 @@ jobs:
   - task: MicroBuildSigningPlugin@3
     name: ''
     displayName: Install Signing Plugin
+    condition: and(succeeded(), ne(parameters.SignTypeToUse, 'none'))
     enabled: True
     inputs:
       signType: ${{ parameters.SignTypeToUse }}
@@ -131,18 +147,18 @@ jobs:
   - task: VSBuild@1
     name: ''
     displayName: Build client.sln for Loc and Tests
-    condition: and(succeeded(), eq(variables['RunTests'], 'true'))
+    condition: and(succeeded(), eq(parameters.RunTests, 'true'))
     enabled: True
     inputs:
       solution: src/client.sln
       msbuildArgs: -p:Localize=true -p:ConsumeEndpointManager=false
-      configuration: $(BuildConfiguration)
+      configuration: ${{ parameters.BuildConfiguration }}
   - task: VSTest@2
     displayName: Run Unit Tests
-    condition: and(succeeded(), eq(variables['RunTests'], 'true'))
+    condition: and(succeeded(), eq(parameters.RunTests, 'true'))
     enabled: True
     inputs:
-      testAssemblyVer2: '**\bin\$(BuildConfiguration)\*\*Tests.dll'
+      testAssemblyVer2: '**\bin\${{ parameters.BuildConfiguration }}\*\*Tests.dll'
       runSettingsFile: tests/unittests/dotnetcore.runsettings
       runInParallel: true
       codeCoverageEnabled: True
@@ -151,7 +167,7 @@ jobs:
       rerunFailedTests: true
   - task: CopyFiles@2
     displayName: Collect Loc files
-    condition: and(succeeded(), eq(variables['RunTests'], 'true'))
+    condition: and(succeeded(), eq(parameters.RunTests, 'true'))
     enabled: True
     inputs:
       Contents: >-
@@ -170,7 +186,7 @@ jobs:
       OverWrite: true
   - task: PublishBuildArtifacts@1
     displayName: 'Publish Artifact: Loc'
-    condition: and(succeeded(), eq(variables['RunTests'], 'true'))
+    condition: and(succeeded(), eq(parameters.RunTests, 'true'))
     enabled: True
     inputs:
       PathtoPublish: $(Build.ArtifactStagingDirectory)/Loc
@@ -183,7 +199,7 @@ jobs:
       command: publish
       publishWebProjects: false
       projects: src\dsc\dsc.csproj
-      arguments: -c $(BuildConfiguration) -r win-x64 --no-restore --self-contained true --verbosity detailed
+      arguments: -c ${{ parameters.BuildConfiguration }} -r win-x64 --no-restore --self-contained true --verbosity detailed
       zipAfterPublish: false
       modifyOutputPath: false
       selectOrConfig: config
@@ -194,7 +210,7 @@ jobs:
       command: publish
       publishWebProjects: false
       projects: src\EndpointManagerLauncher\endpointmanagerlauncher.csproj
-      arguments: -c $(BuildConfiguration) -r win-x64 --no-restore --verbosity detailed
+      arguments: -c ${{ parameters.BuildConfiguration }} -r win-x64 --no-restore --verbosity detailed
       zipAfterPublish: false
       modifyOutputPath: false
       selectOrConfig: config
@@ -202,12 +218,12 @@ jobs:
     displayName: Copy EndpointManager Launcher to dsc folder
     enabled: True
     inputs:
-      SourceFolder: src/EndpointManagerLauncher/bin/$(BuildConfiguration)/net6.0/win-x64/publish/
+      SourceFolder: src/EndpointManagerLauncher/bin/${{ parameters.BuildConfiguration }}/net6.0/win-x64/publish/
       Contents: >-
         **/*
 
         !**/*.pdb
-      TargetFolder: src/dsc/bin/$(BuildConfiguration)/net6.0/win-x64/publish/EndpointManagerLauncher
+      TargetFolder: src/dsc/bin/${{ parameters.BuildConfiguration }}/net6.0/win-x64/publish/EndpointManagerLauncher
       OverWrite: true
   - task: DotNetCoreCLI@2
     displayName: publish DSC (OSX)
@@ -216,7 +232,7 @@ jobs:
       command: publish
       publishWebProjects: false
       projects: src\dsc\dsc.csproj
-      arguments: -c $(BuildConfiguration) -r osx-x64 --no-restore --self-contained true --verbosity detailed
+      arguments: -c ${{ parameters.BuildConfiguration }} -r osx-x64 --no-restore --self-contained true --verbosity detailed
       zipAfterPublish: false
       modifyOutputPath: false
       selectOrConfig: config
@@ -227,7 +243,7 @@ jobs:
       command: publish
       publishWebProjects: false
       projects: src\dsc\dsc.csproj
-      arguments: -c $(BuildConfiguration) -r linux-x64 --no-restore --self-contained true --verbosity detailed
+      arguments: -c ${{ parameters.BuildConfiguration }} -r linux-x64 --no-restore --self-contained true --verbosity detailed
       zipAfterPublish: false
       modifyOutputPath: false
       selectOrConfig: config
@@ -238,39 +254,39 @@ jobs:
     inputs:
       targetType: inline
       script: >
-        New-Item -Path './src/dsc/bin/$(BuildConfiguration)/net6.0/win-x64/publish/kubectl' -ItemType Directory
+        New-Item -Path './src/dsc/bin/${{ parameters.BuildConfiguration }}/net6.0/win-x64/publish/kubectl' -ItemType Directory
 
-        New-Item -Path './src/dsc/bin/$(BuildConfiguration)/net6.0/win-x64/publish/kubectl/win' -ItemType Directory
+        New-Item -Path './src/dsc/bin/${{ parameters.BuildConfiguration }}/net6.0/win-x64/publish/kubectl/win' -ItemType Directory
 
-        curl https://dl.k8s.io/release/v1.21.2/bin/windows/amd64/kubectl.exe -OutFile ./src/dsc/bin/$(BuildConfiguration)/net6.0/win-x64/publish/kubectl/win/kubectl.exe
-
-
-        New-Item -Path './src/dsc/bin/$(BuildConfiguration)/net6.0/osx-x64/publish/kubectl' -ItemType Directory
-
-        New-Item -Path './src/dsc/bin/$(BuildConfiguration)/net6.0/osx-x64/publish/kubectl/osx' -ItemType Directory
-
-        curl https://dl.k8s.io/release/v1.21.2/bin/darwin/amd64/kubectl  -OutFile ./src/dsc/bin/$(BuildConfiguration)/net6.0/osx-x64/publish/kubectl/osx/kubectl
+        curl https://dl.k8s.io/release/v1.21.2/bin/windows/amd64/kubectl.exe -OutFile ./src/dsc/bin/${{ parameters.BuildConfiguration }}/net6.0/win-x64/publish/kubectl/win/kubectl.exe
 
 
-        New-Item -Path './src/dsc/bin/$(BuildConfiguration)/net6.0/linux-x64/publish/kubectl' -ItemType Directory
+        New-Item -Path './src/dsc/bin/${{ parameters.BuildConfiguration }}/net6.0/osx-x64/publish/kubectl' -ItemType Directory
 
-        New-Item -Path './src/dsc/bin/$(BuildConfiguration)/net6.0/linux-x64/publish/kubectl/linux' -ItemType Directory
+        New-Item -Path './src/dsc/bin/${{ parameters.BuildConfiguration }}/net6.0/osx-x64/publish/kubectl/osx' -ItemType Directory
 
-        curl https://dl.k8s.io/release/v1.21.2/bin/linux/amd64/kubectl  -OutFile ./src/dsc/bin/$(BuildConfiguration)/net6.0/linux-x64/publish/kubectl/linux/kubectl
+        curl https://dl.k8s.io/release/v1.21.2/bin/darwin/amd64/kubectl  -OutFile ./src/dsc/bin/${{ parameters.BuildConfiguration }}/net6.0/osx-x64/publish/kubectl/osx/kubectl
+
+
+        New-Item -Path './src/dsc/bin/${{ parameters.BuildConfiguration }}/net6.0/linux-x64/publish/kubectl' -ItemType Directory
+
+        New-Item -Path './src/dsc/bin/${{ parameters.BuildConfiguration }}/net6.0/linux-x64/publish/kubectl/linux' -ItemType Directory
+
+        curl https://dl.k8s.io/release/v1.21.2/bin/linux/amd64/kubectl  -OutFile ./src/dsc/bin/${{ parameters.BuildConfiguration }}/net6.0/linux-x64/publish/kubectl/linux/kubectl
   - task: VSBuild@1
     name: ''
     displayName: Sign Files
-    condition: and(succeeded(), eq(variables['RunTests'], 'true'))
+    condition: and(succeeded(), eq(parameters.RunTests, 'true'))
     enabled: True
     inputs:
       solution: src/client.signproj
       msbuildArgs: /t:SignFiles /p:SignType=${{ parameters.SignTypeToUse }}
-      configuration: '$(BuildConfiguration) '
+      configuration: '${{ parameters.BuildConfiguration }} '
   - task: CopyFiles@2
     displayName: Collect files for .zip (Windows)
     enabled: True
     inputs:
-      SourceFolder: src/dsc/bin/$(BuildConfiguration)/net6.0/win-x64/publish
+      SourceFolder: src/dsc/bin/${{ parameters.BuildConfiguration }}/net6.0/win-x64/publish
       Contents: >-
         **/*
 
@@ -310,7 +326,7 @@ jobs:
     displayName: Collect files for .zip (OSX)
     enabled: True
     inputs:
-      SourceFolder: src/dsc/bin/$(BuildConfiguration)/net6.0/osx-x64/publish
+      SourceFolder: src/dsc/bin/${{ parameters.BuildConfiguration }}/net6.0/osx-x64/publish
       Contents: >-
         **/*
 
@@ -354,7 +370,7 @@ jobs:
     displayName: Collect files for .zip (Linux)
     enabled: True
     inputs:
-      SourceFolder: src/dsc/bin/$(BuildConfiguration)/net6.0/linux-x64/publish
+      SourceFolder: src/dsc/bin/${{ parameters.BuildConfiguration }}/net6.0/linux-x64/publish
       Contents: >-
         **/*
 
@@ -465,7 +481,7 @@ jobs:
       packagesToPack: src/dsc/dsc.csproj
       packDirectory: '$(Build.ArtifactStagingDirectory)/nuget'
       nobuild: true
-      buildProperties: 'NuspecFile=bin\$(BuildConfiguration)\net6.0\win-x64\publish\dsc.nuspec'
+      buildProperties: 'NuspecFile=bin\${{ parameters.BuildConfiguration }}\net6.0\win-x64\publish\dsc.nuspec'
   - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
     displayName: 'Manifest Generator for nuget'
     inputs:
@@ -479,7 +495,7 @@ jobs:
     displayName: Collect Build Symbols - dsc
     enabled: True
     inputs:
-      SourceFolder: src/dsc/bin/$(BuildConfiguration)/net6.0
+      SourceFolder: src/dsc/bin/${{ parameters.BuildConfiguration }}/net6.0
       Contents: >-
         */publish/dsc.?(pdb|exe|dll|)
 
@@ -492,7 +508,7 @@ jobs:
       OverWrite: true
   - task: PublishSymbols@2
     displayName: Enable Source Server
-    condition: and(succeeded(), eq(variables['RunTests'], 'true'))
+    condition: and(succeeded(), eq(parameters.RunTests, 'true'))
     enabled: True
     inputs:
       SymbolsFolder: $(Build.ArtifactStagingDirectory)/symbols
@@ -508,7 +524,7 @@ jobs:
       OverWrite: true
   - task: PublishBuildArtifacts@1
     displayName: 'Publish Artifact: symbols'
-    condition: and(succeeded(), eq(variables['RunTests'], 'true'))
+    condition: and(succeeded(), eq(parameters.RunTests, 'true'))
     enabled: True
     inputs:
       PathtoPublish: $(Build.ArtifactStagingDirectory)/symbols
@@ -516,10 +532,10 @@ jobs:
       TargetPath: '\\my\share\$(Build.DefinitionName)\$(Build.BuildNumber)'
   - task: tagBuildOrRelease@0
     displayName: Tag BuildConfiguration
-    condition: and(succeeded(), ne(variables['BuildConfiguration'], 'release'))
+    condition: and(succeeded(), ne(parameters.BuildConfiguration, 'release'))
     enabled: True
     inputs:
-      tags: 'BuildConfiguration: $(BuildConfiguration)'
+      tags: 'BuildConfiguration: ${{ parameters.BuildConfiguration }}'
 - job: Phase_2
   displayName: Run NON self-contained build (binaries V2, where the binaries are downloaded in parallel)
   timeoutInMinutes: 120
@@ -543,7 +559,7 @@ jobs:
         $branchName = $env:BUILD_SOURCEBRANCH
 
         if ($branchName -eq "refs/heads/main") {
-            Write-Host "##vso[task.setvariable variable=TelemetryType]TELEMETRY_PRODUCTION"
+            Write-Host "##vso[task.setvariable variable=TelemetryType]"{{ parameters.TelemetryType }}
             Write-Host "Done setting the sign type and telemetry key instance for staging branch"
         }
 
@@ -588,7 +604,7 @@ jobs:
       command: publish
       publishWebProjects: false
       projects: src\dsc\dsc.csproj
-      arguments: -c $(BuildConfiguration) -r win-x64 --self-contained false --no-restore --verbosity detailed
+      arguments: -c ${{ parameters.BuildConfiguration }} -r win-x64 --self-contained false --no-restore --verbosity detailed
       zipAfterPublish: false
       modifyOutputPath: false
   - task: CmdLine@2
@@ -603,19 +619,19 @@ jobs:
   - task: CopyFiles@2
     displayName: Copy EndpointManager Launcher to dsc folder
     inputs:
-      SourceFolder: src/EndpointManagerLauncher/bin/$(BuildConfiguration)/net6.0/win-x64/publish/
+      SourceFolder: src/EndpointManagerLauncher/bin/${{ parameters.BuildConfiguration }}/net6.0/win-x64/publish/
       Contents: >-
         **/*
 
         !**/*.pdb
-      TargetFolder: src/dsc/bin/$(BuildConfiguration)/net6.0/win-x64/publish/EndpointManagerLauncher
+      TargetFolder: src/dsc/bin/${{ parameters.BuildConfiguration }}/net6.0/win-x64/publish/EndpointManagerLauncher
   - task: DotNetCoreCLI@2
     displayName: publish DSC (OSX)
     inputs:
       command: publish
       publishWebProjects: false
       projects: src\dsc\dsc.csproj
-      arguments: -c $(BuildConfiguration) -r osx-x64 --no-restore --self-contained false --verbosity detailed
+      arguments: -c ${{ parameters.BuildConfiguration }} -r osx-x64 --no-restore --self-contained false --verbosity detailed
       zipAfterPublish: false
       modifyOutputPath: false
   - task: DotNetCoreCLI@2
@@ -624,7 +640,7 @@ jobs:
       command: publish
       publishWebProjects: false
       projects: src\dsc\dsc.csproj
-      arguments: -c $(BuildConfiguration) -r linux-x64 --no-restore --self-contained false --verbosity detailed
+      arguments: -c ${{ parameters.BuildConfiguration }} -r linux-x64 --no-restore --self-contained false --verbosity detailed
       zipAfterPublish: false
       modifyOutputPath: false
   - task: PowerShell@2
@@ -633,35 +649,35 @@ jobs:
     inputs:
       targetType: inline
       script: >
-        New-Item -Path '$(Build.SourcesDirectory)/src/dsc/bin/$(BuildConfiguration)/net6.0/win-x64/publish/kubectl' -ItemType Directory
+        New-Item -Path '$(Build.SourcesDirectory)/src/dsc/bin/${{ parameters.BuildConfiguration }}/net6.0/win-x64/publish/kubectl' -ItemType Directory
 
-        New-Item -Path '$(Build.SourcesDirectory)/src/dsc/bin/$(BuildConfiguration)/net6.0/win-x64/publish/kubectl/win' -ItemType Directory
+        New-Item -Path '$(Build.SourcesDirectory)/src/dsc/bin/${{ parameters.BuildConfiguration }}/net6.0/win-x64/publish/kubectl/win' -ItemType Directory
 
-        curl https://dl.k8s.io/release/v1.21.2/bin/windows/amd64/kubectl.exe -OutFile $(Build.SourcesDirectory)/src/dsc/bin/$(BuildConfiguration)/net6.0/win-x64/publish/kubectl/win/kubectl.exe
-
-
-        New-Item -Path '$(Build.SourcesDirectory)/src/dsc/bin/$(BuildConfiguration)/net6.0/osx-x64/publish/kubectl' -ItemType Directory
-
-        New-Item -Path '$(Build.SourcesDirectory)/src/dsc/bin/$(BuildConfiguration)/net6.0/osx-x64/publish/kubectl/osx' -ItemType Directory
-
-        curl https://dl.k8s.io/release/v1.21.2/bin/darwin/amd64/kubectl  -OutFile $(Build.SourcesDirectory)/src/dsc/bin/$(BuildConfiguration)/net6.0/osx-x64/publish/kubectl/osx/kubectl
+        curl https://dl.k8s.io/release/v1.21.2/bin/windows/amd64/kubectl.exe -OutFile $(Build.SourcesDirectory)/src/dsc/bin/${{ parameters.BuildConfiguration }}/net6.0/win-x64/publish/kubectl/win/kubectl.exe
 
 
-        New-Item -Path '$(Build.SourcesDirectory)/src/dsc/bin/$(BuildConfiguration)/net6.0/linux-x64/publish/kubectl' -ItemType Directory
+        New-Item -Path '$(Build.SourcesDirectory)/src/dsc/bin/${{ parameters.BuildConfiguration }}/net6.0/osx-x64/publish/kubectl' -ItemType Directory
 
-        New-Item -Path '$(Build.SourcesDirectory)/src/dsc/bin/$(BuildConfiguration)/net6.0/linux-x64/publish/kubectl/linux' -ItemType Directory
+        New-Item -Path '$(Build.SourcesDirectory)/src/dsc/bin/${{ parameters.BuildConfiguration }}/net6.0/osx-x64/publish/kubectl/osx' -ItemType Directory
 
-        curl https://dl.k8s.io/release/v1.21.2/bin/linux/amd64/kubectl  -OutFile $(Build.SourcesDirectory)/src/dsc/bin/$(BuildConfiguration)/net6.0/linux-x64/publish/kubectl/linux/kubectl
+        curl https://dl.k8s.io/release/v1.21.2/bin/darwin/amd64/kubectl  -OutFile $(Build.SourcesDirectory)/src/dsc/bin/${{ parameters.BuildConfiguration }}/net6.0/osx-x64/publish/kubectl/osx/kubectl
+
+
+        New-Item -Path '$(Build.SourcesDirectory)/src/dsc/bin/${{ parameters.BuildConfiguration }}/net6.0/linux-x64/publish/kubectl' -ItemType Directory
+
+        New-Item -Path '$(Build.SourcesDirectory)/src/dsc/bin/${{ parameters.BuildConfiguration }}/net6.0/linux-x64/publish/kubectl/linux' -ItemType Directory
+
+        curl https://dl.k8s.io/release/v1.21.2/bin/linux/amd64/kubectl  -OutFile $(Build.SourcesDirectory)/src/dsc/bin/${{ parameters.BuildConfiguration }}/net6.0/linux-x64/publish/kubectl/linux/kubectl
   - task: VSBuild@1
     displayName: Sign Files
     inputs:
       solution: src/client.signproj
       msbuildArgs: /t:SignFiles /p:SignType=${{ parameters.SignTypeToUse }}
-      configuration: '$(BuildConfiguration) '
+      configuration: '${{ parameters.BuildConfiguration }} '
   - task: CopyFiles@2
     displayName: Collect files for .zip (Windows)
     inputs:
-      SourceFolder: src/dsc/bin/$(BuildConfiguration)/net6.0/win-x64/publish
+      SourceFolder: src/dsc/bin/${{ parameters.BuildConfiguration }}/net6.0/win-x64/publish
       Contents: >-
         **/*
 
@@ -700,7 +716,7 @@ jobs:
   - task: CopyFiles@2
     displayName: Collect files for .zip (OSX)
     inputs:
-      SourceFolder: src/dsc/bin/$(BuildConfiguration)/net6.0/osx-x64/publish
+      SourceFolder: src/dsc/bin/${{ parameters.BuildConfiguration }}/net6.0/osx-x64/publish
       Contents: >-
         **/*
 
@@ -743,7 +759,7 @@ jobs:
   - task: CopyFiles@2
     displayName: Collect files for .zip (Linux)
     inputs:
-      SourceFolder: src/dsc/bin/$(BuildConfiguration)/net6.0/linux-x64/publish
+      SourceFolder: src/dsc/bin/${{ parameters.BuildConfiguration }}/net6.0/linux-x64/publish
       Contents: >-
         **/*
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,888 +1,887 @@
 # 'Allow scripts to access the OAuth token' was selected in pipeline.  Add the following YAML to any steps requiring access:
-    #       env:
-    #           MY_ACCESS_TOKEN: $(System.AccessToken)
-    # Variable 'ArtifactServices.Symbol.AccountName' was defined in the Variables tab
-    # Variable 'ArtifactServices.Symbol.PAT' was defined in the Variables tab
-    # Variable 'ArtifactServices.Symbol.UseAAD' was defined in the Variables tab
-    # Variable 'DropRoot' was defined in the Variables tab
-    # Variable 'ForceProductionBuild' was defined in the Variables tab
-    # Variable 'ForceStagingBuild' was defined in the Variables tab
-    # Variable 'MSI_BuildVersion' was defined in the Variables tab
-    # Variable 'RunTests' was defined in the Variables tab
-    # Variable 'skipComponentGovernanceDetection' was defined in the Variables tab
-    # Variable 'system.prefergit' was defined in the Variables tab
-    # Variable 'TeamName' was defined in the Variables tab
-    # Variable 'TelemetryType' was defined in the Variables tab
-    parameters:
-      - name: SignTypeToUse
-        displayName: Signing Type
-        default: 'test'
-        values:
-        - test
-        - real
-      - name: TelemetryType
-        displayName: Telemetry Type so that correct application insights key is selected
-        default: 'TELEMETRY_DEVELOPMENT'
-        values:
-        - TELEMETRY_DEVELOPMENT
-        - TELEMETRY_STAGING
-        - TELEMETRY_PRODUCTION
-      - name: BuildConfiguration
-        displayName: BuildConfiguration to be used
-        default: 'Release'
-        values:
-        - Release
-        - Debug
-    variables:
-    - name: BuildParameters.dotnetversion
-      value: 6.0.x
-    - name: BuildParameters.nugetversion
-      value: 5.9.x
-    - name: TeamName
-      value: Mindaro
-    - name: RunTests
-      value: True
-    
-    trigger:
-      branches:
-        include:
-        - refs/heads/main
-      batch: True
-    name: $(date:yyyyMMdd)$(rev:.r)
-    resources:
-      repositories:
-      - repository: self
-        type: git
-        ref: refs/heads/main
-    jobs:
-    - job: Phase_1
-      displayName: Run self-contained build (binaries V1, where the binaries are all bundled together)
-      timeoutInMinutes: 120
-      cancelTimeoutInMinutes: 1
-      pool:
-        name: 'VSEngSS-MicroBuild2022-1ES'
-        demands:
-        - msbuild
-        - visualstudio
-        - DotNetFramework
-      steps:
-      - checkout: self
-        clean: true
-        fetchTags: false
-        persistCredentials: True
-      - task: PowerShell@2
-        displayName: Set staging/prod build vars for signing and telemetry copy
-        enabled: True
-        inputs:
-          targetType: inline
-          script: >-
-            if ($env:ForceStagingBuild -eq "true" -And $env:ForceProductionBuild -eq "true") {
-              Write-Host "You can't do a Staging and Production build at the same time... Duh...."
-              exit 1
-            }
-    
-    
-            $branchName = $env:BUILD_SOURCEBRANCH
-    
-            if ($branchName -eq "refs/heads/main") {
-                Write-Host "##vso[task.setvariable variable=TelemetryType]"{{ parameters.TelemetryType }}
-                Write-Host "Done setting the sign type and telemetry key instance for main branch"
-            }
-    
-    
-            Write-Host "Disabling NuGet package signing because it doesn't work, and we don't publish public NuGet packages"
-    
-            Write-Host "##vso[task.setvariable variable=MicroBuild_NuPkgSigningEnabled]false"
-      - task: MicroBuildSigningPlugin@3
-        name: ''
-        displayName: Install Signing Plugin
-        enabled: True
-        inputs:
-          signType: ${{ parameters.SignTypeToUse }}
-          zipSources: false
-      - task: MicroBuildLocalizationPlugin@3
-        displayName: 'Install Localization Plugin'
-        enabled: True
-      - task: UseDotNet@2
-        displayName: Use .NET Core SDK 6.0.x
-        enabled: True
-        inputs:
-          version: $(BuildParameters.dotnetversion)
-          installationPath: $(Agent.TempDirectory)/dotnet
-      - task: DotNetCoreCLI@2
-        displayName: restore EndpointManager (Windows) (to download runtime pack)
-        enabled: True
-        inputs:
-          command: restore
-          projects: src\endpointmanager\endpointmanager.csproj
-          restoreArguments: -r win-x64
-          selectOrConfig: config
-          nugetConfigPath: src/nuget.config
-          externalEndpoints: dba0ba50-2d4e-4f12-9f5a-42a638da803b
-      - task: NuGetToolInstaller@1
-        name: ''
-        displayName: Use NuGet 5.9.x
-        enabled: True
-        inputs:
-          versionSpec: $(BuildParameters.nugetversion)
-      - task: NuGetCommand@2
-        name: ''
-        displayName: NuGet restore client.sln
-        enabled: True
-        inputs:
-          solution: src/client.sln
-          selectOrConfig: config
-          feedRestore: fc5819b5-ed1c-4a51-9766-a55ddb558d72
-          nugetConfigPath: src/nuget.config
-          externalEndpoints: dba0ba50-2d4e-4f12-9f5a-42a638da803b
-          verbosityRestore: Normal
-          searchPatternPush: $(Build.ArtifactStagingDirectory)/*.nupkg
-      - task: VSBuild@1
-        name: ''
-        displayName: Build client.sln for Loc and Tests
-        condition: and(succeeded(), eq(variables.RunTests, 'true'))
-        enabled: True
-        inputs:
-          solution: src/client.sln
-          msbuildArgs: -p:Localize=true -p:ConsumeEndpointManager=false
-          configuration: ${{ parameters.BuildConfiguration }}
-      - task: VSTest@2
-        displayName: Run Unit Tests
-        condition: and(succeeded(), eq(variables.RunTests, 'true'))
-        enabled: True
-        inputs:
-          testAssemblyVer2: '**\bin\${{ parameters.BuildConfiguration }}\*\*Tests.dll'
-          runSettingsFile: tests/unittests/dotnetcore.runsettings
-          runInParallel: true
-          codeCoverageEnabled: True
-          testRunTitle: Unit Tests
-          failOnMinTestsNotRun: true
-          rerunFailedTests: true
-      - task: CopyFiles@2
-        displayName: Collect Loc files
-        condition: and(succeeded(), eq(variables.RunTests, 'true'))
-        enabled: True
-        inputs:
-          Contents: >-
-            src/*/bin/*/*/localize/**/*
-    
-            src/*/bin/**/*.lce
-    
-            src/dsc/bin/*/*/dsc.dll
-    
-            src/endpointmanager/bin/*/*/endpointmanager.dll
-    
-            src/common/bin/*/*/Microsoft.BridgeToKubernetes.Common.dll
-    
-            src/library/bin/*/*/Microsoft.BridgeToKubernetes.Library.dll
-          TargetFolder: $(Build.ArtifactStagingDirectory)/Loc
-          OverWrite: true
-      - task: PublishBuildArtifacts@1
-        displayName: 'Publish Artifact: Loc'
-        condition: and(succeeded(), eq(variables.RunTests, 'true'))
-        enabled: True
-        inputs:
-          PathtoPublish: $(Build.ArtifactStagingDirectory)/Loc
-          ArtifactName: Loc
-          TargetPath: '\\my\share\$(Build.DefinitionName)\$(Build.BuildNumber)'
-      - task: DotNetCoreCLI@2
-        displayName: publish DSC (Windows)
-        enabled: True
-        inputs:
-          command: publish
-          publishWebProjects: false
-          projects: src\dsc\dsc.csproj
-          arguments: -c ${{ parameters.BuildConfiguration }} -r win-x64 --no-restore --self-contained true --verbosity detailed
-          zipAfterPublish: false
-          modifyOutputPath: false
-          selectOrConfig: config
-      - task: DotNetCoreCLI@2
-        displayName: publish EndpointManagerLauncher(Windows)
-        enabled: True
-        inputs:
-          command: publish
-          publishWebProjects: false
-          projects: src\EndpointManagerLauncher\endpointmanagerlauncher.csproj
-          arguments: -c ${{ parameters.BuildConfiguration }} -r win-x64 --no-restore --verbosity detailed
-          zipAfterPublish: false
-          modifyOutputPath: false
-          selectOrConfig: config
-      - task: CopyFiles@2
-        displayName: Copy EndpointManager Launcher to dsc folder
-        enabled: True
-        inputs:
-          SourceFolder: src/EndpointManagerLauncher/bin/${{ parameters.BuildConfiguration }}/net6.0/win-x64/publish/
-          Contents: >-
-            **/*
-    
-            !**/*.pdb
-          TargetFolder: src/dsc/bin/${{ parameters.BuildConfiguration }}/net6.0/win-x64/publish/EndpointManagerLauncher
-          OverWrite: true
-      - task: DotNetCoreCLI@2
-        displayName: publish DSC (OSX)
-        enabled: True
-        inputs:
-          command: publish
-          publishWebProjects: false
-          projects: src\dsc\dsc.csproj
-          arguments: -c ${{ parameters.BuildConfiguration }} -r osx-x64 --no-restore --self-contained true --verbosity detailed
-          zipAfterPublish: false
-          modifyOutputPath: false
-          selectOrConfig: config
-      - task: DotNetCoreCLI@2
-        displayName: publish DSC (Linux)
-        enabled: True
-        inputs:
-          command: publish
-          publishWebProjects: false
-          projects: src\dsc\dsc.csproj
-          arguments: -c ${{ parameters.BuildConfiguration }} -r linux-x64 --no-restore --self-contained true --verbosity detailed
-          zipAfterPublish: false
-          modifyOutputPath: false
-          selectOrConfig: config
-      - task: PowerShell@2
-        displayName: Download kubectl
-        continueOnError: True
-        enabled: True
-        inputs:
-          targetType: inline
-          script: >
-            New-Item -Path './src/dsc/bin/${{ parameters.BuildConfiguration }}/net6.0/win-x64/publish/kubectl' -ItemType Directory
-    
-            New-Item -Path './src/dsc/bin/${{ parameters.BuildConfiguration }}/net6.0/win-x64/publish/kubectl/win' -ItemType Directory
-    
-            curl https://dl.k8s.io/release/v1.21.2/bin/windows/amd64/kubectl.exe -OutFile ./src/dsc/bin/${{ parameters.BuildConfiguration }}/net6.0/win-x64/publish/kubectl/win/kubectl.exe
-    
-    
-            New-Item -Path './src/dsc/bin/${{ parameters.BuildConfiguration }}/net6.0/osx-x64/publish/kubectl' -ItemType Directory
-    
-            New-Item -Path './src/dsc/bin/${{ parameters.BuildConfiguration }}/net6.0/osx-x64/publish/kubectl/osx' -ItemType Directory
-    
-            curl https://dl.k8s.io/release/v1.21.2/bin/darwin/amd64/kubectl  -OutFile ./src/dsc/bin/${{ parameters.BuildConfiguration }}/net6.0/osx-x64/publish/kubectl/osx/kubectl
-    
-    
-            New-Item -Path './src/dsc/bin/${{ parameters.BuildConfiguration }}/net6.0/linux-x64/publish/kubectl' -ItemType Directory
-    
-            New-Item -Path './src/dsc/bin/${{ parameters.BuildConfiguration }}/net6.0/linux-x64/publish/kubectl/linux' -ItemType Directory
-    
-            curl https://dl.k8s.io/release/v1.21.2/bin/linux/amd64/kubectl  -OutFile ./src/dsc/bin/${{ parameters.BuildConfiguration }}/net6.0/linux-x64/publish/kubectl/linux/kubectl
-      - task: VSBuild@1
-        name: ''
-        displayName: Sign Files
-        enabled: True
-        inputs:
-          solution: src/client.signproj
-          msbuildArgs: /t:SignFiles /p:SignType=${{ parameters.SignTypeToUse }}
-          configuration: '${{ parameters.BuildConfiguration }} '
-      - task: CopyFiles@2
-        displayName: Collect files for .zip (Windows)
-        enabled: True
-        inputs:
-          SourceFolder: src/dsc/bin/${{ parameters.BuildConfiguration }}/net6.0/win-x64/publish
-          Contents: >-
-            **/*
-    
-            !**/*.pdb
-    
-            !**/*.xml
-    
-            !**/*.nuspec
-    
-            !**/cs/*
-    
-            !**/de/*
-    
-            !**/es/*
-    
-            !**/fr/*
-    
-            !**/it/*
-    
-            !**/ja/*
-    
-            !**/ko/*
-    
-            !**/pl/*
-    
-            !**/pt-BR/*
-    
-            !**/ru/*
-    
-            !**/tr/*
-    
-            !**/zh-Hans/*
-    
-            !**/zh-Hant/*
-          TargetFolder: $(Agent.TempDirectory)/zip/win
-      - task: CopyFiles@2
-        displayName: Collect files for .zip (OSX)
-        enabled: True
-        inputs:
-          SourceFolder: src/dsc/bin/${{ parameters.BuildConfiguration }}/net6.0/osx-x64/publish
-          Contents: >-
-            **/*
-    
-            src/resources/license.rtf
-    
-            src/vscode/ThirdPartyNotices.txt
-    
-            !**/*.pdb
-    
-            !**/*.xml
-    
-            !**/*.nuspec
-    
-            !**/cs/*
-    
-            !**/de/*
-    
-            !**/es/*
-    
-            !**/fr/*
-    
-            !**/it/*
-    
-            !**/ja/*
-    
-            !**/ko/*
-    
-            !**/pl/*
-    
-            !**/pt-BR/*
-    
-            !**/ru/*
-    
-            !**/tr/*
-    
-            !**/zh-Hans/*
-    
-            !**/zh-Hant/*
-          TargetFolder: $(Agent.TempDirectory)/zip/osx
-      - task: CopyFiles@2
-        displayName: Collect files for .zip (Linux)
-        enabled: True
-        inputs:
-          SourceFolder: src/dsc/bin/${{ parameters.BuildConfiguration }}/net6.0/linux-x64/publish
-          Contents: >-
-            **/*
-    
-            src/resources/license.rtf
-    
-            src/vscode/ThirdPartyNotices.txt
-    
-            !**/*.pdb
-    
-            !**/*.xml
-    
-            !**/*.nuspec
-    
-            !**/cs/*
-    
-            !**/de/*
-    
-            !**/es/*
-    
-            !**/fr/*
-    
-            !**/it/*
-    
-            !**/ja/*
-    
-            !**/ko/*
-    
-            !**/pl/*
-    
-            !**/pt-BR/*
-    
-            !**/ru/*
-    
-            !**/tr/*
-    
-            !**/zh-Hans/*
-    
-            !**/zh-Hant/*
-          TargetFolder: $(Agent.TempDirectory)/zip/linux
-      - task: ArchiveFiles@2
-        displayName: Create .zip file (Windows)
-        enabled: True
-        inputs:
-          rootFolderOrFile: $(Agent.TempDirectory)/zip/win
-          includeRootFolder: false
-          sevenZipCompression: 5
-          archiveFile: $(Build.ArtifactStagingDirectory)/zip/lpk-win.zip
-      - task: ArchiveFiles@2
-        displayName: Create .zip file (OSX)
-        enabled: True
-        inputs:
-          rootFolderOrFile: $(Agent.TempDirectory)/zip/osx
-          includeRootFolder: false
-          sevenZipCompression: 5
-          archiveFile: $(Build.ArtifactStagingDirectory)/zip/lpk-osx.zip
-      - task: ArchiveFiles@2
-        displayName: Create .zip file (Linux)
-        enabled: True
-        inputs:
-          rootFolderOrFile: $(Agent.TempDirectory)/zip/linux
-          includeRootFolder: false
-          sevenZipCompression: 5
-          archiveFile: $(Build.ArtifactStagingDirectory)/zip/lpk-linux.zip
-      - task: PowerShell@2
-        displayName: Generate lks.json for .zip files
-        enabled: True
-        inputs:
-          targetType: inline
-          script: >-
-            $ZipHost = "mindaromaster.blob.core.windows.net"
-    
-            $BlobUrl = "https://$ZipHost/zip/1.0.$env:BUILD_BUILDNUMBER"
-    
-            $ZipDir = "$env:BUILD_ARTIFACTSTAGINGDIRECTORY/zip"
-    
-            $Win = @{ url="$BlobUrl/lpk-win.zip"; sha256hash="$((Get-FileHash $ZipDir\lpk-win.zip).Hash)" }
-    
-            $OSX = @{ url="$BlobUrl/lpk-osx.zip"; sha256hash="$((Get-FileHash $ZipDir\lpk-osx.zip).Hash)" }
-    
-            $Linux = @{ url="$BlobUrl/lpk-linux.zip"; sha256hash="$((Get-FileHash $ZipDir\lpk-linux.zip).Hash)" }
-    
-            $Json = @{ version="1.0.$env:BUILD_BUILDNUMBER"; win = $Win; osx = $OSX; linux = $Linux } | ConvertTo-Json
-    
-            $Json | Out-File -FilePath $ZipDir/lks.json -Encoding ascii
-    
-            New-Item -ItemType directory -Path $ZipDir/1.0.$env:BUILD_BUILDNUMBER
-    
-            $Json | Out-File -FilePath $ZipDir/1.0.$env:BUILD_BUILDNUMBER/lks.json -Encoding ascii
-    
-            Write-Host $Json
-      - task: ManifestGeneratorTask@0
-        displayName: Manifest Generator for zip
-        enabled: True
-        inputs:
-          BuildDropPath: $(Build.ArtifactStagingDirectory)/zip
-      - task: PublishBuildArtifacts@1
-        displayName: 'Publish Artifact: zip'
-        enabled: True
-        inputs:
-          PathtoPublish: $(Build.ArtifactStagingDirectory)/zip
-          ArtifactName: zip
-          TargetPath: '\\my\share\$(Build.DefinitionName)\$(Build.BuildNumber)'
-      - task: DotNetCoreCLI@2
-        displayName: 'dotnet pack CLI NuGet (Windows)'
-        inputs:
-          command: pack
-          feedsToUse: config
-          packagesToPack: src/dsc/dsc.csproj
-          packDirectory: '$(Build.ArtifactStagingDirectory)/nuget'
-          nobuild: true
-          buildProperties: 'NuspecFile=bin\${{ parameters.BuildConfiguration }}\net6.0\win-x64\publish\dsc.nuspec'
-      - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
-        displayName: 'Manifest Generator for nuget'
-        inputs:
-          BuildDropPath: '$(Build.ArtifactStagingDirectory)/nuget'
-      - task: PublishBuildArtifacts@1
-        displayName: 'Publish Artifact: nuget'
-        inputs:
-          PathtoPublish: '$(Build.ArtifactStagingDirectory)/nuget'
-          ArtifactName: nuget
-      - task: CopyFiles@2
-        displayName: Collect Build Symbols - dsc
-        enabled: True
-        inputs:
-          SourceFolder: src/dsc/bin/${{ parameters.BuildConfiguration }}/net6.0
-          Contents: >-
-            */publish/dsc.?(pdb|exe|dll|)
-    
-            */publish/Microsoft.BridgeToKubernetes.*.@(pdb|exe|dll|)
-    
-            */publish/EndpointManager/EndpointManager.?(pdb|exe|dll|)
-    
-            */publish/EndpointManager/Microsoft.BridgeToKubernetes.*.@(pdb|exe|dll|)
-          TargetFolder: $(Build.ArtifactStagingDirectory)/symbols
-          OverWrite: true
-      - task: PublishSymbols@2
-        displayName: Enable Source Server
-        condition: and(succeeded(), eq(variables.RunTests, 'true'))
-        enabled: True
-        inputs:
-          SymbolsFolder: $(Build.ArtifactStagingDirectory)/symbols
-          SearchPattern: '**/*.pdb'
-          SymbolServerType: TeamServices
-      - task: CopyFiles@2
-        displayName: Copy buildWindowsPDBs.ps1 to artifact directory
-        enabled: True
-        inputs:
-          SourceFolder: build
-          Contents: buildWindowsPDBs.ps1
-          TargetFolder: $(Build.ArtifactStagingDirectory)/symbols/
-          OverWrite: true
-      - task: PublishBuildArtifacts@1
-        displayName: 'Publish Artifact: symbols'
-        condition: and(succeeded(), eq(variables.RunTests, 'true'))
-        enabled: True
-        inputs:
-          PathtoPublish: $(Build.ArtifactStagingDirectory)/symbols
-          ArtifactName: symbols
-          TargetPath: '\\my\share\$(Build.DefinitionName)\$(Build.BuildNumber)'
-      - task: tagBuildOrRelease@0
-        displayName: Tag BuildConfiguration
-        enabled: True
-        inputs:
-          tags: 'BuildConfiguration: ${{ parameters.BuildConfiguration }}'
-    - job: Phase_2
-      displayName: Run NON self-contained build (binaries V2, where the binaries are downloaded in parallel)
-      timeoutInMinutes: 120
-      cancelTimeoutInMinutes: 1
-      pool:
-        name: 'VSEngSS-MicroBuild2022-1ES'
-        demands:
-        - msbuild
-        - visualstudio
-        - vstest
-      steps:
-      - checkout: self
-        clean: true
-        fetchTags: false
-        persistCredentials: True
-      - task: PowerShell@2
-        displayName: Set staging/prod build vars for signing and telemetry
-        inputs:
-          targetType: inline
-          script: >-
-            $branchName = $env:BUILD_SOURCEBRANCH
-    
-            if ($branchName -eq "refs/heads/main") {
-                Write-Host "##vso[task.setvariable variable=TelemetryType]"{{ parameters.TelemetryType }}
-                Write-Host "Done setting the sign type and telemetry key instance for staging branch"
-            }
-    
-            Write-Host "Disabling NuGet package signing because it doesn't work, and we don't publish public NuGet packages"
-    
-            Write-Host "##vso[task.setvariable variable=MicroBuild_NuPkgSigningEnabled]false"
-      - task: MicroBuildSigningPlugin@3
-        displayName: Install Signing Plugin
-        enabled: True
-        inputs:
-          signType: ${{ parameters.SignTypeToUse }}
-          zipSources: false
-      - task: MicroBuildLocalizationPlugin@3
-        displayName: Install Localization Plugin
-      - task: UseDotNet@2
-        displayName: Use .NET Core SDK 6.0.X
-        inputs:
-          version: 6.0.306
-          installationPath: $(Agent.TempDirectory)/dotnet
-      - task: DotNetCoreCLI@2
-        displayName: restore EndpointManager (Windows) (to download runtime pack)
-        inputs:
-          command: restore
-          projects: src\endpointmanager\endpointmanager.csproj
-          restoreArguments: -r win-x64
-          selectOrConfig: config
-          nugetConfigPath: src/nuget.config
-          externalEndpoints: dba0ba50-2d4e-4f12-9f5a-42a638da803b
-      - task: NuGetToolInstaller@1
-        displayName: Use NuGet 6.1.x
-        inputs:
-          versionSpec: 6.1.x
-      - task: NuGetCommand@2
-        displayName: NuGet restore client.sln
-        inputs:
-          solution: src/client.sln
-          selectOrConfig: config
-          nugetConfigPath: src/nuget.config
-          externalEndpoints: dba0ba50-2d4e-4f12-9f5a-42a638da803b
-      - task: DotNetCoreCLI@2
-        displayName: publish DSC (Windows)
-        inputs:
-          command: publish
-          publishWebProjects: false
-          projects: src\dsc\dsc.csproj
-          arguments: -c ${{ parameters.BuildConfiguration }} -r win-x64 --self-contained false --no-restore --verbosity detailed
-          zipAfterPublish: false
-          modifyOutputPath: false
-      - task: DotNetCoreCLI@2
-        displayName: publish EndpointManagerLauncher(Windows)
-        enabled: True
-        inputs:
-          command: publish
-          publishWebProjects: false
-          projects: src\EndpointManagerLauncher\endpointmanagerlauncher.csproj
-          arguments: -c ${{ parameters.BuildConfiguration }} -r win-x64 --no-restore --verbosity detailed
-          zipAfterPublish: false
-          modifyOutputPath: false
-          selectOrConfig: config
-      - task: CopyFiles@2
-        displayName: Copy EndpointManager Launcher to dsc folder
-        enabled: True
-        inputs:
-          SourceFolder: src/EndpointManagerLauncher/bin/${{ parameters.BuildConfiguration }}/net6.0/win-x64/publish/
-          Contents: >-
-            **/*
-    
-            !**/*.pdb
-          TargetFolder: src/dsc/bin/${{ parameters.BuildConfiguration }}/net6.0/win-x64/publish/EndpointManagerLauncher
-          OverWrite: true
-      - task: DotNetCoreCLI@2
-        displayName: publish DSC (OSX)
-        inputs:
-          command: publish
-          publishWebProjects: false
-          projects: src\dsc\dsc.csproj
-          arguments: -c ${{ parameters.BuildConfiguration }} -r osx-x64 --no-restore --self-contained false --verbosity detailed
-          zipAfterPublish: false
-          modifyOutputPath: false
-      - task: DotNetCoreCLI@2
-        displayName: publish DSC (Linux)
-        inputs:
-          command: publish
-          publishWebProjects: false
-          projects: src\dsc\dsc.csproj
-          arguments: -c ${{ parameters.BuildConfiguration }} -r linux-x64 --no-restore --self-contained false --verbosity detailed
-          zipAfterPublish: false
-          modifyOutputPath: false
-      - task: PowerShell@2
-        displayName: Download kubectl
-        continueOnError: True
-        inputs:
-          targetType: inline
-          script: >
-            New-Item -Path '$(Build.SourcesDirectory)/src/dsc/bin/${{ parameters.BuildConfiguration }}/net6.0/win-x64/publish/kubectl' -ItemType Directory
-    
-            New-Item -Path '$(Build.SourcesDirectory)/src/dsc/bin/${{ parameters.BuildConfiguration }}/net6.0/win-x64/publish/kubectl/win' -ItemType Directory
-    
-            curl https://dl.k8s.io/release/v1.21.2/bin/windows/amd64/kubectl.exe -OutFile $(Build.SourcesDirectory)/src/dsc/bin/${{ parameters.BuildConfiguration }}/net6.0/win-x64/publish/kubectl/win/kubectl.exe
-    
-    
-            New-Item -Path '$(Build.SourcesDirectory)/src/dsc/bin/${{ parameters.BuildConfiguration }}/net6.0/osx-x64/publish/kubectl' -ItemType Directory
-    
-            New-Item -Path '$(Build.SourcesDirectory)/src/dsc/bin/${{ parameters.BuildConfiguration }}/net6.0/osx-x64/publish/kubectl/osx' -ItemType Directory
-    
-            curl https://dl.k8s.io/release/v1.21.2/bin/darwin/amd64/kubectl  -OutFile $(Build.SourcesDirectory)/src/dsc/bin/${{ parameters.BuildConfiguration }}/net6.0/osx-x64/publish/kubectl/osx/kubectl
-    
-    
-            New-Item -Path '$(Build.SourcesDirectory)/src/dsc/bin/${{ parameters.BuildConfiguration }}/net6.0/linux-x64/publish/kubectl' -ItemType Directory
-    
-            New-Item -Path '$(Build.SourcesDirectory)/src/dsc/bin/${{ parameters.BuildConfiguration }}/net6.0/linux-x64/publish/kubectl/linux' -ItemType Directory
-    
-            curl https://dl.k8s.io/release/v1.21.2/bin/linux/amd64/kubectl  -OutFile $(Build.SourcesDirectory)/src/dsc/bin/${{ parameters.BuildConfiguration }}/net6.0/linux-x64/publish/kubectl/linux/kubectl
-      - task: VSBuild@1
-        displayName: Sign Files
-        enabled: True
-        inputs:
-          solution: src/client.signproj
-          msbuildArgs: /t:SignFiles /p:SignType=${{ parameters.SignTypeToUse }}
-          configuration: '${{ parameters.BuildConfiguration }} '
-      - task: CopyFiles@2
-        displayName: Collect files for .zip (Windows)
-        inputs:
-          SourceFolder: src/dsc/bin/${{ parameters.BuildConfiguration }}/net6.0/win-x64/publish
-          Contents: >-
-            **/*
-    
-            !**/*.pdb
-    
-            !**/*.xml
-    
-            !**/*.nuspec
-    
-            !**/cs/*
-    
-            !**/de/*
-    
-            !**/es/*
-    
-            !**/fr/*
-    
-            !**/it/*
-    
-            !**/ja/*
-    
-            !**/ko/*
-    
-            !**/pl/*
-    
-            !**/pt-BR/*
-    
-            !**/ru/*
-    
-            !**/tr/*
-    
-            !**/zh-Hans/*
-    
-            !**/zh-Hant/*
-          TargetFolder: $(Agent.TempDirectory)/zip/win
-      - task: CopyFiles@2
-        displayName: Collect files for .zip (OSX)
-        inputs:
-          SourceFolder: src/dsc/bin/${{ parameters.BuildConfiguration }}/net6.0/osx-x64/publish
-          Contents: >-
-            **/*
-    
-            src/resources/license.rtf
-    
-            src/vscode/ThirdPartyNotices.txt
-    
-            !**/*.pdb
-    
-            !**/*.xml
-    
-            !**/*.nuspec
-    
-            !**/cs/*
-    
-            !**/de/*
-    
-            !**/es/*
-    
-            !**/fr/*
-    
-            !**/it/*
-    
-            !**/ja/*
-    
-            !**/ko/*
-    
-            !**/pl/*
-    
-            !**/pt-BR/*
-    
-            !**/ru/*
-    
-            !**/tr/*
-    
-            !**/zh-Hans/*
-    
-            !**/zh-Hant/*
-          TargetFolder: $(Agent.TempDirectory)/zip/osx
-      - task: CopyFiles@2
-        displayName: Collect files for .zip (Linux)
-        inputs:
-          SourceFolder: src/dsc/bin/${{ parameters.BuildConfiguration }}/net6.0/linux-x64/publish
-          Contents: >-
-            **/*
-    
-            src/resources/license.rtf
-    
-            src/vscode/ThirdPartyNotices.txt
-    
-            !**/*.pdb
-    
-            !**/*.xml
-    
-            !**/*.nuspec
-    
-            !**/cs/*
-    
-            !**/de/*
-    
-            !**/es/*
-    
-            !**/fr/*
-    
-            !**/it/*
-    
-            !**/ja/*
-    
-            !**/ko/*
-    
-            !**/pl/*
-    
-            !**/pt-BR/*
-    
-            !**/ru/*
-    
-            !**/tr/*
-    
-            !**/zh-Hans/*
-    
-            !**/zh-Hant/*
-          TargetFolder: $(Agent.TempDirectory)/zip/linux
-      - task: ArchiveFiles@2
-        displayName: Create .zip file (Windows)
-        inputs:
-          rootFolderOrFile: $(Agent.TempDirectory)/zip/win
-          includeRootFolder: false
-          sevenZipCompression: 5
-          archiveFile: $(Build.ArtifactStagingDirectory)/zip/lpk-win.zip
-      - task: ArchiveFiles@2
-        displayName: Create .zip file (OSX)
-        inputs:
-          rootFolderOrFile: $(Agent.TempDirectory)/zip/osx
-          includeRootFolder: false
-          sevenZipCompression: 5
-          archiveFile: $(Build.ArtifactStagingDirectory)/zip/lpk-osx.zip
-      - task: ArchiveFiles@2
-        displayName: Create .zip file (Linux)
-        inputs:
-          rootFolderOrFile: $(Agent.TempDirectory)/zip/linux
-          includeRootFolder: false
-          sevenZipCompression: 5
-          archiveFile: $(Build.ArtifactStagingDirectory)/zip/lpk-linux.zip
-      - task: PowerShell@2
-        displayName: Generate lks.json for .zip files
-        inputs:
-          targetType: inline
-          script: >
-            $ZipHost = "mindaromaster.blob.core.windows.net"
-    
-            $BlobUrl = "https://$ZipHost/zipv2/1.0.$env:BUILD_BUILDNUMBER"
-    
-            $BlobLKSUrl = "https://$ZipHost/zipv2/LKS"
-    
-            $ZipDir = "$env:BUILD_ARTIFACTSTAGINGDIRECTORY/zip"
-    
-            # CLI binaries
-    
-            $Cli_Win = @{ url="$BlobUrl/lpk-win.zip"; sha256hash="$((Get-FileHash $ZipDir\lpk-win.zip).Hash)" }
-    
-            $Cli_Osx = @{ url="$BlobUrl/lpk-osx.zip"; sha256hash="$((Get-FileHash $ZipDir\lpk-osx.zip).Hash)" }
-    
-            $Cli_Linux = @{ url="$BlobUrl/lpk-linux.zip"; sha256hash="$((Get-FileHash $ZipDir\lpk-linux.zip).Hash)" }
-    
-            # Kubectl binaries
-    
-            $Kubectl_Win = @{ url="$BlobLKSUrl/kubectl-win.zip"; sha256hash="5490F9B60E4C2C4229CA00FBFA946AE65655F0739BE9714C6A0A0FB7BE2A6F2C" }
-    
-            $Kubectl_Osx = @{ url="$BlobLKSUrl/kubectl-osx.zip"; sha256hash="D24EAFEC39EB2393DBA0088B762953BEDCC04156AC9E324FA290476BD3C888B9" }
-    
-            $Kubectl_Linux = @{ url="$BlobLKSUrl/kubectl-linux.zip"; sha256hash="01B76D4E4A9081452932F27C767C9D8F3507C8AD3CC9269CEB16729F4D0ED900" }
-    
-            #dotnet runtime binaries
-    
-            $Dotnet_Win = @{ url="$BlobLKSUrl/dotnetruntime-win.zip"; sha256hash="0FCA9F2AB829C85615007EA646CF436D2E90C9A4095C84C2F9EB3EC0754468A8" }
-    
-            $Dotnet_Osx = @{ url="$BlobLKSUrl/dotnetruntime-osx.zip"; sha256hash="D25F8BB708C364678AAA0F3798F5EADD1BE46800376F15D2F12C785C74AF8443" }
-    
-            $Dotnet_Linux = @{ url="$BlobLKSUrl/dotnetruntime-linux.zip"; sha256hash="801D9D251D07B9A88195450FCBFD70C7507CEEEF05D5F0E88CC14CEBFCC10F4B" }
-    
-            # Win Json
-    
-            $Win = @{ dotnetruntime = $Dotnet_Win; kubectl = $Kubectl_Win; bridge = $Cli_Win }
-    
-            # OSX Json
-    
-            $OSX = @{ dotnetruntime = $Dotnet_Osx; kubectl = $Kubectl_Osx; bridge = $Cli_Osx }
-    
-            # Linux Json
-    
-            $Linux = @{ dotnetruntime = $Dotnet_Linux; kubectl = $Kubectl_Linux; bridge = $Cli_Linux }
-    
-            $Json = @{ version="1.0.$env:BUILD_BUILDNUMBER"; win = $Win; osx = $OSX; linux = $Linux } | ConvertTo-Json
-    
-            $Json | Out-File -FilePath $ZipDir/lks.json -Encoding ascii
-    
-            New-Item -ItemType directory -Path $ZipDir/1.0.$env:BUILD_BUILDNUMBER
-    
-            $Json | Out-File -FilePath $ZipDir/1.0.$env:BUILD_BUILDNUMBER/lks.json -Encoding ascii
-    
-            Write-Host $Json
-      - task: ManifestGeneratorTask@0
-        displayName: Manifest Generator for zip
-        inputs:
-          BuildDropPath: $(Build.ArtifactStagingDirectory)/zip/
-      - task: PublishBuildArtifacts@1
-        displayName: Generate lks.json for .zip files
-        inputs:
-          PathtoPublish: $(Build.ArtifactStagingDirectory)/zip
-          ArtifactName: zipv2
-    ...
-    
+#       env:
+#           MY_ACCESS_TOKEN: $(System.AccessToken)
+# Variable 'ArtifactServices.Symbol.AccountName' was defined in the Variables tab
+# Variable 'ArtifactServices.Symbol.PAT' was defined in the Variables tab
+# Variable 'ArtifactServices.Symbol.UseAAD' was defined in the Variables tab
+# Variable 'DropRoot' was defined in the Variables tab
+# Variable 'ForceProductionBuild' was defined in the Variables tab
+# Variable 'ForceStagingBuild' was defined in the Variables tab
+# Variable 'MSI_BuildVersion' was defined in the Variables tab
+# Variable 'RunTests' was defined in the Variables tab
+# Variable 'skipComponentGovernanceDetection' was defined in the Variables tab
+# Variable 'system.prefergit' was defined in the Variables tab
+# Variable 'TeamName' was defined in the Variables tab
+# Variable 'TelemetryType' was defined in the Variables tab
+parameters:
+  - name: SignTypeToUse
+    displayName: Signing Type
+    default: 'test'
+    values:
+    - test
+    - real
+  - name: TelemetryType
+    displayName: Telemetry Type so that correct application insights key is selected
+    default: 'TELEMETRY_DEVELOPMENT'
+    values:
+    - TELEMETRY_DEVELOPMENT
+    - TELEMETRY_STAGING
+    - TELEMETRY_PRODUCTION
+  - name: BuildConfiguration
+    displayName: BuildConfiguration to be used
+    default: 'Release'
+    values:
+    - Release
+    - Debug
+variables:
+- name: BuildParameters.dotnetversion
+  value: 6.0.x
+- name: BuildParameters.nugetversion
+  value: 5.9.x
+- name: TeamName
+  value: Mindaro
+- name: RunTests
+  value: True
+
+trigger:
+  branches:
+    include:
+    - refs/heads/main
+  batch: True
+name: $(date:yyyyMMdd)$(rev:.r)
+resources:
+  repositories:
+  - repository: self
+    type: git
+    ref: refs/heads/main
+jobs:
+- job: Phase_1
+  displayName: Run self-contained build (binaries V1, where the binaries are all bundled together)
+  timeoutInMinutes: 120
+  cancelTimeoutInMinutes: 1
+  pool:
+    name: 'VSEngSS-MicroBuild2022-1ES'
+    demands:
+    - msbuild
+    - visualstudio
+    - DotNetFramework
+  steps:
+  - checkout: self
+    clean: true
+    fetchTags: false
+    persistCredentials: True
+  - task: PowerShell@2
+    displayName: Set staging/prod build vars for signing and telemetry copy
+    enabled: True
+    inputs:
+      targetType: inline
+      script: >-
+        if ($env:ForceStagingBuild -eq "true" -And $env:ForceProductionBuild -eq "true") {
+          Write-Host "You can't do a Staging and Production build at the same time... Duh...."
+          exit 1
+        }
+
+
+        $branchName = $env:BUILD_SOURCEBRANCH
+
+        if ($branchName -eq "refs/heads/main") {
+            Write-Host "##vso[task.setvariable variable=TelemetryType]"{{ parameters.TelemetryType }}
+            Write-Host "Done setting the sign type and telemetry key instance for main branch"
+        }
+
+
+        Write-Host "Disabling NuGet package signing because it doesn't work, and we don't publish public NuGet packages"
+
+        Write-Host "##vso[task.setvariable variable=MicroBuild_NuPkgSigningEnabled]false"
+  - task: MicroBuildSigningPlugin@3
+    name: ''
+    displayName: Install Signing Plugin
+    enabled: True
+    inputs:
+      signType: ${{ parameters.SignTypeToUse }}
+      zipSources: false
+  - task: MicroBuildLocalizationPlugin@3
+    displayName: 'Install Localization Plugin'
+    enabled: True
+  - task: UseDotNet@2
+    displayName: Use .NET Core SDK 6.0.x
+    enabled: True
+    inputs:
+      version: $(BuildParameters.dotnetversion)
+      installationPath: $(Agent.TempDirectory)/dotnet
+  - task: DotNetCoreCLI@2
+    displayName: restore EndpointManager (Windows) (to download runtime pack)
+    enabled: True
+    inputs:
+      command: restore
+      projects: src\endpointmanager\endpointmanager.csproj
+      restoreArguments: -r win-x64
+      selectOrConfig: config
+      nugetConfigPath: src/nuget.config
+      externalEndpoints: dba0ba50-2d4e-4f12-9f5a-42a638da803b
+  - task: NuGetToolInstaller@1
+    name: ''
+    displayName: Use NuGet 5.9.x
+    enabled: True
+    inputs:
+      versionSpec: $(BuildParameters.nugetversion)
+  - task: NuGetCommand@2
+    name: ''
+    displayName: NuGet restore client.sln
+    enabled: True
+    inputs:
+      solution: src/client.sln
+      selectOrConfig: config
+      feedRestore: fc5819b5-ed1c-4a51-9766-a55ddb558d72
+      nugetConfigPath: src/nuget.config
+      externalEndpoints: dba0ba50-2d4e-4f12-9f5a-42a638da803b
+      verbosityRestore: Normal
+      searchPatternPush: $(Build.ArtifactStagingDirectory)/*.nupkg
+  - task: VSBuild@1
+    name: ''
+    displayName: Build client.sln for Loc and Tests
+    condition: and(succeeded(), eq(variables.RunTests, 'true'))
+    enabled: True
+    inputs:
+      solution: src/client.sln
+      msbuildArgs: -p:Localize=true -p:ConsumeEndpointManager=false
+      configuration: ${{ parameters.BuildConfiguration }}
+  - task: VSTest@2
+    displayName: Run Unit Tests
+    condition: and(succeeded(), eq(variables.RunTests, 'true'))
+    enabled: True
+    inputs:
+      testAssemblyVer2: '**\bin\${{ parameters.BuildConfiguration }}\*\*Tests.dll'
+      runSettingsFile: tests/unittests/dotnetcore.runsettings
+      runInParallel: true
+      codeCoverageEnabled: True
+      testRunTitle: Unit Tests
+      failOnMinTestsNotRun: true
+      rerunFailedTests: true
+  - task: CopyFiles@2
+    displayName: Collect Loc files
+    condition: and(succeeded(), eq(variables.RunTests, 'true'))
+    enabled: True
+    inputs:
+      Contents: >-
+        src/*/bin/*/*/localize/**/*
+
+        src/*/bin/**/*.lce
+
+        src/dsc/bin/*/*/dsc.dll
+
+        src/endpointmanager/bin/*/*/endpointmanager.dll
+
+        src/common/bin/*/*/Microsoft.BridgeToKubernetes.Common.dll
+
+        src/library/bin/*/*/Microsoft.BridgeToKubernetes.Library.dll
+      TargetFolder: $(Build.ArtifactStagingDirectory)/Loc
+      OverWrite: true
+  - task: PublishBuildArtifacts@1
+    displayName: 'Publish Artifact: Loc'
+    condition: and(succeeded(), eq(variables.RunTests, 'true'))
+    enabled: True
+    inputs:
+      PathtoPublish: $(Build.ArtifactStagingDirectory)/Loc
+      ArtifactName: Loc
+      TargetPath: '\\my\share\$(Build.DefinitionName)\$(Build.BuildNumber)'
+  - task: DotNetCoreCLI@2
+    displayName: publish DSC (Windows)
+    enabled: True
+    inputs:
+      command: publish
+      publishWebProjects: false
+      projects: src\dsc\dsc.csproj
+      arguments: -c ${{ parameters.BuildConfiguration }} -r win-x64 --no-restore --self-contained true --verbosity detailed
+      zipAfterPublish: false
+      modifyOutputPath: false
+      selectOrConfig: config
+  - task: DotNetCoreCLI@2
+    displayName: publish EndpointManagerLauncher(Windows)
+    enabled: True
+    inputs:
+      command: publish
+      publishWebProjects: false
+      projects: src\EndpointManagerLauncher\endpointmanagerlauncher.csproj
+      arguments: -c ${{ parameters.BuildConfiguration }} -r win-x64 --no-restore --verbosity detailed
+      zipAfterPublish: false
+      modifyOutputPath: false
+      selectOrConfig: config
+  - task: CopyFiles@2
+    displayName: Copy EndpointManager Launcher to dsc folder
+    enabled: True
+    inputs:
+      SourceFolder: src/EndpointManagerLauncher/bin/${{ parameters.BuildConfiguration }}/net6.0/win-x64/publish/
+      Contents: >-
+        **/*
+
+        !**/*.pdb
+      TargetFolder: src/dsc/bin/${{ parameters.BuildConfiguration }}/net6.0/win-x64/publish/EndpointManagerLauncher
+      OverWrite: true
+  - task: DotNetCoreCLI@2
+    displayName: publish DSC (OSX)
+    enabled: True
+    inputs:
+      command: publish
+      publishWebProjects: false
+      projects: src\dsc\dsc.csproj
+      arguments: -c ${{ parameters.BuildConfiguration }} -r osx-x64 --no-restore --self-contained true --verbosity detailed
+      zipAfterPublish: false
+      modifyOutputPath: false
+      selectOrConfig: config
+  - task: DotNetCoreCLI@2
+    displayName: publish DSC (Linux)
+    enabled: True
+    inputs:
+      command: publish
+      publishWebProjects: false
+      projects: src\dsc\dsc.csproj
+      arguments: -c ${{ parameters.BuildConfiguration }} -r linux-x64 --no-restore --self-contained true --verbosity detailed
+      zipAfterPublish: false
+      modifyOutputPath: false
+      selectOrConfig: config
+  - task: PowerShell@2
+    displayName: Download kubectl
+    continueOnError: True
+    enabled: True
+    inputs:
+      targetType: inline
+      script: >
+        New-Item -Path './src/dsc/bin/${{ parameters.BuildConfiguration }}/net6.0/win-x64/publish/kubectl' -ItemType Directory
+
+        New-Item -Path './src/dsc/bin/${{ parameters.BuildConfiguration }}/net6.0/win-x64/publish/kubectl/win' -ItemType Directory
+
+        curl https://dl.k8s.io/release/v1.21.2/bin/windows/amd64/kubectl.exe -OutFile ./src/dsc/bin/${{ parameters.BuildConfiguration }}/net6.0/win-x64/publish/kubectl/win/kubectl.exe
+
+
+        New-Item -Path './src/dsc/bin/${{ parameters.BuildConfiguration }}/net6.0/osx-x64/publish/kubectl' -ItemType Directory
+
+        New-Item -Path './src/dsc/bin/${{ parameters.BuildConfiguration }}/net6.0/osx-x64/publish/kubectl/osx' -ItemType Directory
+
+        curl https://dl.k8s.io/release/v1.21.2/bin/darwin/amd64/kubectl  -OutFile ./src/dsc/bin/${{ parameters.BuildConfiguration }}/net6.0/osx-x64/publish/kubectl/osx/kubectl
+
+
+        New-Item -Path './src/dsc/bin/${{ parameters.BuildConfiguration }}/net6.0/linux-x64/publish/kubectl' -ItemType Directory
+
+        New-Item -Path './src/dsc/bin/${{ parameters.BuildConfiguration }}/net6.0/linux-x64/publish/kubectl/linux' -ItemType Directory
+
+        curl https://dl.k8s.io/release/v1.21.2/bin/linux/amd64/kubectl  -OutFile ./src/dsc/bin/${{ parameters.BuildConfiguration }}/net6.0/linux-x64/publish/kubectl/linux/kubectl
+  - task: VSBuild@1
+    name: ''
+    displayName: Sign Files
+    enabled: True
+    inputs:
+      solution: src/client.signproj
+      msbuildArgs: /t:SignFiles /p:SignType=${{ parameters.SignTypeToUse }}
+      configuration: '${{ parameters.BuildConfiguration }} '
+  - task: CopyFiles@2
+    displayName: Collect files for .zip (Windows)
+    enabled: True
+    inputs:
+      SourceFolder: src/dsc/bin/${{ parameters.BuildConfiguration }}/net6.0/win-x64/publish
+      Contents: >-
+        **/*
+
+        !**/*.pdb
+
+        !**/*.xml
+
+        !**/*.nuspec
+
+        !**/cs/*
+
+        !**/de/*
+
+        !**/es/*
+
+        !**/fr/*
+
+        !**/it/*
+
+        !**/ja/*
+
+        !**/ko/*
+
+        !**/pl/*
+
+        !**/pt-BR/*
+
+        !**/ru/*
+
+        !**/tr/*
+
+        !**/zh-Hans/*
+
+        !**/zh-Hant/*
+      TargetFolder: $(Agent.TempDirectory)/zip/win
+  - task: CopyFiles@2
+    displayName: Collect files for .zip (OSX)
+    enabled: True
+    inputs:
+      SourceFolder: src/dsc/bin/${{ parameters.BuildConfiguration }}/net6.0/osx-x64/publish
+      Contents: >-
+        **/*
+
+        src/resources/license.rtf
+
+        src/vscode/ThirdPartyNotices.txt
+
+        !**/*.pdb
+
+        !**/*.xml
+
+        !**/*.nuspec
+
+        !**/cs/*
+
+        !**/de/*
+
+        !**/es/*
+
+        !**/fr/*
+
+        !**/it/*
+
+        !**/ja/*
+
+        !**/ko/*
+
+        !**/pl/*
+
+        !**/pt-BR/*
+
+        !**/ru/*
+
+        !**/tr/*
+
+        !**/zh-Hans/*
+
+        !**/zh-Hant/*
+      TargetFolder: $(Agent.TempDirectory)/zip/osx
+  - task: CopyFiles@2
+    displayName: Collect files for .zip (Linux)
+    enabled: True
+    inputs:
+      SourceFolder: src/dsc/bin/${{ parameters.BuildConfiguration }}/net6.0/linux-x64/publish
+      Contents: >-
+        **/*
+
+        src/resources/license.rtf
+
+        src/vscode/ThirdPartyNotices.txt
+
+        !**/*.pdb
+
+        !**/*.xml
+
+        !**/*.nuspec
+
+        !**/cs/*
+
+        !**/de/*
+
+        !**/es/*
+
+        !**/fr/*
+
+        !**/it/*
+
+        !**/ja/*
+
+        !**/ko/*
+
+        !**/pl/*
+
+        !**/pt-BR/*
+
+        !**/ru/*
+
+        !**/tr/*
+
+        !**/zh-Hans/*
+
+        !**/zh-Hant/*
+      TargetFolder: $(Agent.TempDirectory)/zip/linux
+  - task: ArchiveFiles@2
+    displayName: Create .zip file (Windows)
+    enabled: True
+    inputs:
+      rootFolderOrFile: $(Agent.TempDirectory)/zip/win
+      includeRootFolder: false
+      sevenZipCompression: 5
+      archiveFile: $(Build.ArtifactStagingDirectory)/zip/lpk-win.zip
+  - task: ArchiveFiles@2
+    displayName: Create .zip file (OSX)
+    enabled: True
+    inputs:
+      rootFolderOrFile: $(Agent.TempDirectory)/zip/osx
+      includeRootFolder: false
+      sevenZipCompression: 5
+      archiveFile: $(Build.ArtifactStagingDirectory)/zip/lpk-osx.zip
+  - task: ArchiveFiles@2
+    displayName: Create .zip file (Linux)
+    enabled: True
+    inputs:
+      rootFolderOrFile: $(Agent.TempDirectory)/zip/linux
+      includeRootFolder: false
+      sevenZipCompression: 5
+      archiveFile: $(Build.ArtifactStagingDirectory)/zip/lpk-linux.zip
+  - task: PowerShell@2
+    displayName: Generate lks.json for .zip files
+    enabled: True
+    inputs:
+      targetType: inline
+      script: >-
+        $ZipHost = "mindaromaster.blob.core.windows.net"
+
+        $BlobUrl = "https://$ZipHost/zip/1.0.$env:BUILD_BUILDNUMBER"
+
+        $ZipDir = "$env:BUILD_ARTIFACTSTAGINGDIRECTORY/zip"
+
+        $Win = @{ url="$BlobUrl/lpk-win.zip"; sha256hash="$((Get-FileHash $ZipDir\lpk-win.zip).Hash)" }
+
+        $OSX = @{ url="$BlobUrl/lpk-osx.zip"; sha256hash="$((Get-FileHash $ZipDir\lpk-osx.zip).Hash)" }
+
+        $Linux = @{ url="$BlobUrl/lpk-linux.zip"; sha256hash="$((Get-FileHash $ZipDir\lpk-linux.zip).Hash)" }
+
+        $Json = @{ version="1.0.$env:BUILD_BUILDNUMBER"; win = $Win; osx = $OSX; linux = $Linux } | ConvertTo-Json
+
+        $Json | Out-File -FilePath $ZipDir/lks.json -Encoding ascii
+
+        New-Item -ItemType directory -Path $ZipDir/1.0.$env:BUILD_BUILDNUMBER
+
+        $Json | Out-File -FilePath $ZipDir/1.0.$env:BUILD_BUILDNUMBER/lks.json -Encoding ascii
+
+        Write-Host $Json
+  - task: ManifestGeneratorTask@0
+    displayName: Manifest Generator for zip
+    enabled: True
+    inputs:
+      BuildDropPath: $(Build.ArtifactStagingDirectory)/zip
+  - task: PublishBuildArtifacts@1
+    displayName: 'Publish Artifact: zip'
+    enabled: True
+    inputs:
+      PathtoPublish: $(Build.ArtifactStagingDirectory)/zip
+      ArtifactName: zip
+      TargetPath: '\\my\share\$(Build.DefinitionName)\$(Build.BuildNumber)'
+  - task: DotNetCoreCLI@2
+    displayName: 'dotnet pack CLI NuGet (Windows)'
+    inputs:
+      command: pack
+      feedsToUse: config
+      packagesToPack: src/dsc/dsc.csproj
+      packDirectory: '$(Build.ArtifactStagingDirectory)/nuget'
+      nobuild: true
+      buildProperties: 'NuspecFile=bin\${{ parameters.BuildConfiguration }}\net6.0\win-x64\publish\dsc.nuspec'
+  - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
+    displayName: 'Manifest Generator for nuget'
+    inputs:
+      BuildDropPath: '$(Build.ArtifactStagingDirectory)/nuget'
+  - task: PublishBuildArtifacts@1
+    displayName: 'Publish Artifact: nuget'
+    inputs:
+      PathtoPublish: '$(Build.ArtifactStagingDirectory)/nuget'
+      ArtifactName: nuget
+  - task: CopyFiles@2
+    displayName: Collect Build Symbols - dsc
+    enabled: True
+    inputs:
+      SourceFolder: src/dsc/bin/${{ parameters.BuildConfiguration }}/net6.0
+      Contents: >-
+        */publish/dsc.?(pdb|exe|dll|)
+
+        */publish/Microsoft.BridgeToKubernetes.*.@(pdb|exe|dll|)
+
+        */publish/EndpointManager/EndpointManager.?(pdb|exe|dll|)
+
+        */publish/EndpointManager/Microsoft.BridgeToKubernetes.*.@(pdb|exe|dll|)
+      TargetFolder: $(Build.ArtifactStagingDirectory)/symbols
+      OverWrite: true
+  - task: PublishSymbols@2
+    displayName: Enable Source Server
+    condition: and(succeeded(), eq(variables.RunTests, 'true'))
+    enabled: True
+    inputs:
+      SymbolsFolder: $(Build.ArtifactStagingDirectory)/symbols
+      SearchPattern: '**/*.pdb'
+      SymbolServerType: TeamServices
+  - task: CopyFiles@2
+    displayName: Copy buildWindowsPDBs.ps1 to artifact directory
+    enabled: True
+    inputs:
+      SourceFolder: build
+      Contents: buildWindowsPDBs.ps1
+      TargetFolder: $(Build.ArtifactStagingDirectory)/symbols/
+      OverWrite: true
+  - task: PublishBuildArtifacts@1
+    displayName: 'Publish Artifact: symbols'
+    condition: and(succeeded(), eq(variables.RunTests, 'true'))
+    enabled: True
+    inputs:
+      PathtoPublish: $(Build.ArtifactStagingDirectory)/symbols
+      ArtifactName: symbols
+      TargetPath: '\\my\share\$(Build.DefinitionName)\$(Build.BuildNumber)'
+  - task: tagBuildOrRelease@0
+    displayName: Tag BuildConfiguration
+    enabled: True
+    inputs:
+      tags: 'BuildConfiguration: ${{ parameters.BuildConfiguration }}'
+- job: Phase_2
+  displayName: Run NON self-contained build (binaries V2, where the binaries are downloaded in parallel)
+  timeoutInMinutes: 120
+  cancelTimeoutInMinutes: 1
+  pool:
+    name: 'VSEngSS-MicroBuild2022-1ES'
+    demands:
+    - msbuild
+    - visualstudio
+    - vstest
+  steps:
+  - checkout: self
+    clean: true
+    fetchTags: false
+    persistCredentials: True
+  - task: PowerShell@2
+    displayName: Set staging/prod build vars for signing and telemetry
+    inputs:
+      targetType: inline
+      script: >-
+        $branchName = $env:BUILD_SOURCEBRANCH
+
+        if ($branchName -eq "refs/heads/main") {
+            Write-Host "##vso[task.setvariable variable=TelemetryType]"{{ parameters.TelemetryType }}
+            Write-Host "Done setting the sign type and telemetry key instance for staging branch"
+        }
+
+        Write-Host "Disabling NuGet package signing because it doesn't work, and we don't publish public NuGet packages"
+
+        Write-Host "##vso[task.setvariable variable=MicroBuild_NuPkgSigningEnabled]false"
+  - task: MicroBuildSigningPlugin@3
+    displayName: Install Signing Plugin
+    enabled: True
+    inputs:
+      signType: ${{ parameters.SignTypeToUse }}
+      zipSources: false
+  - task: MicroBuildLocalizationPlugin@3
+    displayName: Install Localization Plugin
+  - task: UseDotNet@2
+    displayName: Use .NET Core SDK 6.0.X
+    inputs:
+      version: 6.0.306
+      installationPath: $(Agent.TempDirectory)/dotnet
+  - task: DotNetCoreCLI@2
+    displayName: restore EndpointManager (Windows) (to download runtime pack)
+    inputs:
+      command: restore
+      projects: src\endpointmanager\endpointmanager.csproj
+      restoreArguments: -r win-x64
+      selectOrConfig: config
+      nugetConfigPath: src/nuget.config
+      externalEndpoints: dba0ba50-2d4e-4f12-9f5a-42a638da803b
+  - task: NuGetToolInstaller@1
+    displayName: Use NuGet 6.1.x
+    inputs:
+      versionSpec: 6.1.x
+  - task: NuGetCommand@2
+    displayName: NuGet restore client.sln
+    inputs:
+      solution: src/client.sln
+      selectOrConfig: config
+      nugetConfigPath: src/nuget.config
+      externalEndpoints: dba0ba50-2d4e-4f12-9f5a-42a638da803b
+  - task: DotNetCoreCLI@2
+    displayName: publish DSC (Windows)
+    inputs:
+      command: publish
+      publishWebProjects: false
+      projects: src\dsc\dsc.csproj
+      arguments: -c ${{ parameters.BuildConfiguration }} -r win-x64 --self-contained false --no-restore --verbosity detailed
+      zipAfterPublish: false
+      modifyOutputPath: false
+  - task: DotNetCoreCLI@2
+    displayName: publish EndpointManagerLauncher(Windows)
+    enabled: True
+    inputs:
+      command: publish
+      publishWebProjects: false
+      projects: src\EndpointManagerLauncher\endpointmanagerlauncher.csproj
+      arguments: -c ${{ parameters.BuildConfiguration }} -r win-x64 --no-restore --verbosity detailed
+      zipAfterPublish: false
+      modifyOutputPath: false
+      selectOrConfig: config
+  - task: CopyFiles@2
+    displayName: Copy EndpointManager Launcher to dsc folder
+    enabled: True
+    inputs:
+      SourceFolder: src/EndpointManagerLauncher/bin/${{ parameters.BuildConfiguration }}/net6.0/win-x64/publish/
+      Contents: >-
+        **/*
+
+        !**/*.pdb
+      TargetFolder: src/dsc/bin/${{ parameters.BuildConfiguration }}/net6.0/win-x64/publish/EndpointManagerLauncher
+      OverWrite: true
+  - task: DotNetCoreCLI@2
+    displayName: publish DSC (OSX)
+    inputs:
+      command: publish
+      publishWebProjects: false
+      projects: src\dsc\dsc.csproj
+      arguments: -c ${{ parameters.BuildConfiguration }} -r osx-x64 --no-restore --self-contained false --verbosity detailed
+      zipAfterPublish: false
+      modifyOutputPath: false
+  - task: DotNetCoreCLI@2
+    displayName: publish DSC (Linux)
+    inputs:
+      command: publish
+      publishWebProjects: false
+      projects: src\dsc\dsc.csproj
+      arguments: -c ${{ parameters.BuildConfiguration }} -r linux-x64 --no-restore --self-contained false --verbosity detailed
+      zipAfterPublish: false
+      modifyOutputPath: false
+  - task: PowerShell@2
+    displayName: Download kubectl
+    continueOnError: True
+    inputs:
+      targetType: inline
+      script: >
+        New-Item -Path '$(Build.SourcesDirectory)/src/dsc/bin/${{ parameters.BuildConfiguration }}/net6.0/win-x64/publish/kubectl' -ItemType Directory
+
+        New-Item -Path '$(Build.SourcesDirectory)/src/dsc/bin/${{ parameters.BuildConfiguration }}/net6.0/win-x64/publish/kubectl/win' -ItemType Directory
+
+        curl https://dl.k8s.io/release/v1.21.2/bin/windows/amd64/kubectl.exe -OutFile $(Build.SourcesDirectory)/src/dsc/bin/${{ parameters.BuildConfiguration }}/net6.0/win-x64/publish/kubectl/win/kubectl.exe
+
+
+        New-Item -Path '$(Build.SourcesDirectory)/src/dsc/bin/${{ parameters.BuildConfiguration }}/net6.0/osx-x64/publish/kubectl' -ItemType Directory
+
+        New-Item -Path '$(Build.SourcesDirectory)/src/dsc/bin/${{ parameters.BuildConfiguration }}/net6.0/osx-x64/publish/kubectl/osx' -ItemType Directory
+
+        curl https://dl.k8s.io/release/v1.21.2/bin/darwin/amd64/kubectl  -OutFile $(Build.SourcesDirectory)/src/dsc/bin/${{ parameters.BuildConfiguration }}/net6.0/osx-x64/publish/kubectl/osx/kubectl
+
+
+        New-Item -Path '$(Build.SourcesDirectory)/src/dsc/bin/${{ parameters.BuildConfiguration }}/net6.0/linux-x64/publish/kubectl' -ItemType Directory
+
+        New-Item -Path '$(Build.SourcesDirectory)/src/dsc/bin/${{ parameters.BuildConfiguration }}/net6.0/linux-x64/publish/kubectl/linux' -ItemType Directory
+
+        curl https://dl.k8s.io/release/v1.21.2/bin/linux/amd64/kubectl  -OutFile $(Build.SourcesDirectory)/src/dsc/bin/${{ parameters.BuildConfiguration }}/net6.0/linux-x64/publish/kubectl/linux/kubectl
+  - task: VSBuild@1
+    displayName: Sign Files
+    enabled: True
+    inputs:
+      solution: src/client.signproj
+      msbuildArgs: /t:SignFiles /p:SignType=${{ parameters.SignTypeToUse }}
+      configuration: '${{ parameters.BuildConfiguration }} '
+  - task: CopyFiles@2
+    displayName: Collect files for .zip (Windows)
+    inputs:
+      SourceFolder: src/dsc/bin/${{ parameters.BuildConfiguration }}/net6.0/win-x64/publish
+      Contents: >-
+        **/*
+
+        !**/*.pdb
+
+        !**/*.xml
+
+        !**/*.nuspec
+
+        !**/cs/*
+
+        !**/de/*
+
+        !**/es/*
+
+        !**/fr/*
+
+        !**/it/*
+
+        !**/ja/*
+
+        !**/ko/*
+
+        !**/pl/*
+
+        !**/pt-BR/*
+
+        !**/ru/*
+
+        !**/tr/*
+
+        !**/zh-Hans/*
+
+        !**/zh-Hant/*
+      TargetFolder: $(Agent.TempDirectory)/zip/win
+  - task: CopyFiles@2
+    displayName: Collect files for .zip (OSX)
+    inputs:
+      SourceFolder: src/dsc/bin/${{ parameters.BuildConfiguration }}/net6.0/osx-x64/publish
+      Contents: >-
+        **/*
+
+        src/resources/license.rtf
+
+        src/vscode/ThirdPartyNotices.txt
+
+        !**/*.pdb
+
+        !**/*.xml
+
+        !**/*.nuspec
+
+        !**/cs/*
+
+        !**/de/*
+
+        !**/es/*
+
+        !**/fr/*
+
+        !**/it/*
+
+        !**/ja/*
+
+        !**/ko/*
+
+        !**/pl/*
+
+        !**/pt-BR/*
+
+        !**/ru/*
+
+        !**/tr/*
+
+        !**/zh-Hans/*
+
+        !**/zh-Hant/*
+      TargetFolder: $(Agent.TempDirectory)/zip/osx
+  - task: CopyFiles@2
+    displayName: Collect files for .zip (Linux)
+    inputs:
+      SourceFolder: src/dsc/bin/${{ parameters.BuildConfiguration }}/net6.0/linux-x64/publish
+      Contents: >-
+        **/*
+
+        src/resources/license.rtf
+
+        src/vscode/ThirdPartyNotices.txt
+
+        !**/*.pdb
+
+        !**/*.xml
+
+        !**/*.nuspec
+
+        !**/cs/*
+
+        !**/de/*
+
+        !**/es/*
+
+        !**/fr/*
+
+        !**/it/*
+
+        !**/ja/*
+
+        !**/ko/*
+
+        !**/pl/*
+
+        !**/pt-BR/*
+
+        !**/ru/*
+
+        !**/tr/*
+
+        !**/zh-Hans/*
+
+        !**/zh-Hant/*
+      TargetFolder: $(Agent.TempDirectory)/zip/linux
+  - task: ArchiveFiles@2
+    displayName: Create .zip file (Windows)
+    inputs:
+      rootFolderOrFile: $(Agent.TempDirectory)/zip/win
+      includeRootFolder: false
+      sevenZipCompression: 5
+      archiveFile: $(Build.ArtifactStagingDirectory)/zip/lpk-win.zip
+  - task: ArchiveFiles@2
+    displayName: Create .zip file (OSX)
+    inputs:
+      rootFolderOrFile: $(Agent.TempDirectory)/zip/osx
+      includeRootFolder: false
+      sevenZipCompression: 5
+      archiveFile: $(Build.ArtifactStagingDirectory)/zip/lpk-osx.zip
+  - task: ArchiveFiles@2
+    displayName: Create .zip file (Linux)
+    inputs:
+      rootFolderOrFile: $(Agent.TempDirectory)/zip/linux
+      includeRootFolder: false
+      sevenZipCompression: 5
+      archiveFile: $(Build.ArtifactStagingDirectory)/zip/lpk-linux.zip
+  - task: PowerShell@2
+    displayName: Generate lks.json for .zip files
+    inputs:
+      targetType: inline
+      script: >
+        $ZipHost = "mindaromaster.blob.core.windows.net"
+
+        $BlobUrl = "https://$ZipHost/zipv2/1.0.$env:BUILD_BUILDNUMBER"
+
+        $BlobLKSUrl = "https://$ZipHost/zipv2/LKS"
+
+        $ZipDir = "$env:BUILD_ARTIFACTSTAGINGDIRECTORY/zip"
+
+        # CLI binaries
+
+        $Cli_Win = @{ url="$BlobUrl/lpk-win.zip"; sha256hash="$((Get-FileHash $ZipDir\lpk-win.zip).Hash)" }
+
+        $Cli_Osx = @{ url="$BlobUrl/lpk-osx.zip"; sha256hash="$((Get-FileHash $ZipDir\lpk-osx.zip).Hash)" }
+
+        $Cli_Linux = @{ url="$BlobUrl/lpk-linux.zip"; sha256hash="$((Get-FileHash $ZipDir\lpk-linux.zip).Hash)" }
+
+        # Kubectl binaries
+
+        $Kubectl_Win = @{ url="$BlobLKSUrl/kubectl-win.zip"; sha256hash="5490F9B60E4C2C4229CA00FBFA946AE65655F0739BE9714C6A0A0FB7BE2A6F2C" }
+
+        $Kubectl_Osx = @{ url="$BlobLKSUrl/kubectl-osx.zip"; sha256hash="D24EAFEC39EB2393DBA0088B762953BEDCC04156AC9E324FA290476BD3C888B9" }
+
+        $Kubectl_Linux = @{ url="$BlobLKSUrl/kubectl-linux.zip"; sha256hash="01B76D4E4A9081452932F27C767C9D8F3507C8AD3CC9269CEB16729F4D0ED900" }
+
+        #dotnet runtime binaries
+
+        $Dotnet_Win = @{ url="$BlobLKSUrl/dotnetruntime-win.zip"; sha256hash="0FCA9F2AB829C85615007EA646CF436D2E90C9A4095C84C2F9EB3EC0754468A8" }
+
+        $Dotnet_Osx = @{ url="$BlobLKSUrl/dotnetruntime-osx.zip"; sha256hash="D25F8BB708C364678AAA0F3798F5EADD1BE46800376F15D2F12C785C74AF8443" }
+
+        $Dotnet_Linux = @{ url="$BlobLKSUrl/dotnetruntime-linux.zip"; sha256hash="801D9D251D07B9A88195450FCBFD70C7507CEEEF05D5F0E88CC14CEBFCC10F4B" }
+
+        # Win Json
+
+        $Win = @{ dotnetruntime = $Dotnet_Win; kubectl = $Kubectl_Win; bridge = $Cli_Win }
+
+        # OSX Json
+
+        $OSX = @{ dotnetruntime = $Dotnet_Osx; kubectl = $Kubectl_Osx; bridge = $Cli_Osx }
+
+        # Linux Json
+
+        $Linux = @{ dotnetruntime = $Dotnet_Linux; kubectl = $Kubectl_Linux; bridge = $Cli_Linux }
+
+        $Json = @{ version="1.0.$env:BUILD_BUILDNUMBER"; win = $Win; osx = $OSX; linux = $Linux } | ConvertTo-Json
+
+        $Json | Out-File -FilePath $ZipDir/lks.json -Encoding ascii
+
+        New-Item -ItemType directory -Path $ZipDir/1.0.$env:BUILD_BUILDNUMBER
+
+        $Json | Out-File -FilePath $ZipDir/1.0.$env:BUILD_BUILDNUMBER/lks.json -Encoding ascii
+
+        Write-Host $Json
+  - task: ManifestGeneratorTask@0
+    displayName: Manifest Generator for zip
+    inputs:
+      BuildDropPath: $(Build.ArtifactStagingDirectory)/zip/
+  - task: PublishBuildArtifacts@1
+    displayName: Generate lks.json for .zip files
+    inputs:
+      PathtoPublish: $(Build.ArtifactStagingDirectory)/zip
+      ArtifactName: zipv2
+...

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -9,11 +9,18 @@
 # Variable 'ForceStagingBuild' was defined in the Variables tab
 # Variable 'MSI_BuildVersion' was defined in the Variables tab
 # Variable 'RunTests' was defined in the Variables tab
-# Variable 'SignTypeToUse' was defined in the Variables tab
 # Variable 'skipComponentGovernanceDetection' was defined in the Variables tab
 # Variable 'system.prefergit' was defined in the Variables tab
 # Variable 'TeamName' was defined in the Variables tab
 # Variable 'TelemetryType' was defined in the Variables tab
+parameters:
+  - name: SignTypeToUse
+    displayName: Signing Type
+    default: 'test'
+    values:
+    - none
+    - test
+    - real
 variables:
 - name: BuildParameters.dotnetversion
   value: 6.0.x
@@ -23,8 +30,6 @@ variables:
   value: Release
 - name: RunTests
   value: true
-- name: SignTypeToUse
-  value: test
 - name: TeamName
   value: Mindaro
 - name: TelemetryType
@@ -71,7 +76,6 @@ jobs:
         $branchName = $env:BUILD_SOURCEBRANCH
 
         if ($branchName -eq "refs/heads/main") {
-            Write-Host "##vso[task.setvariable variable=SignTypeToUse]test"
             Write-Host "##vso[task.setvariable variable=TelemetryType]TELEMETRY_PRODUCTION"
             Write-Host "Done setting the sign type and telemetry key instance for main branch"
         }
@@ -85,7 +89,7 @@ jobs:
     displayName: Install Signing Plugin
     enabled: True
     inputs:
-      signType: $(SignTypeToUse)
+      signType: ${{ parameters.SignTypeToUse }}
       zipSources: false
   - task: MicroBuildLocalizationPlugin@3
     displayName: 'Install Localization Plugin'
@@ -260,7 +264,7 @@ jobs:
     enabled: True
     inputs:
       solution: src/client.signproj
-      msbuildArgs: /t:SignFiles /p:SignType=$(SignTypeToUse)
+      msbuildArgs: /t:SignFiles /p:SignType=${{ parameters.SignTypeToUse }}
       configuration: '$(BuildConfiguration) '
   - task: CopyFiles@2
     displayName: Collect files for .zip (Windows)
@@ -539,7 +543,6 @@ jobs:
         $branchName = $env:BUILD_SOURCEBRANCH
 
         if ($branchName -eq "refs/heads/main") {
-            Write-Host "##vso[task.setvariable variable=SignTypeToUse]test"
             Write-Host "##vso[task.setvariable variable=TelemetryType]TELEMETRY_PRODUCTION"
             Write-Host "Done setting the sign type and telemetry key instance for staging branch"
         }
@@ -550,7 +553,7 @@ jobs:
   - task: MicroBuildSigningPlugin@3
     displayName: Install Signing Plugin
     inputs:
-      signType: $(SignTypeToUse)
+      signType: ${{ parameters.SignTypeToUse }}
       zipSources: false
   - task: MicroBuildLocalizationPlugin@3
     displayName: Install Localization Plugin
@@ -653,7 +656,7 @@ jobs:
     displayName: Sign Files
     inputs:
       solution: src/client.signproj
-      msbuildArgs: /t:SignFiles /p:SignType=$(SignTypeToUse)
+      msbuildArgs: /t:SignFiles /p:SignType=${{ parameters.SignTypeToUse }}
       configuration: '$(BuildConfiguration) '
   - task: CopyFiles@2
     displayName: Collect files for .zip (Windows)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -18,6 +18,7 @@ parameters:
     displayName: Signing Type
     default: 'test'
     values:
+    - none
     - test
     - real
   - name: TelemetryType

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -524,7 +524,6 @@ jobs:
       TargetPath: '\\my\share\$(Build.DefinitionName)\$(Build.BuildNumber)'
   - task: tagBuildOrRelease@0
     displayName: Tag BuildConfiguration
-    condition: and(succeeded(), ne(parameters.BuildConfiguration, 'release'))
     enabled: True
     inputs:
       tags: 'BuildConfiguration: ${{ parameters.BuildConfiguration }}'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -18,7 +18,6 @@ parameters:
     displayName: Signing Type
     default: 'test'
     values:
-    - none
     - test
     - real
   - name: TelemetryType


### PR DESCRIPTION
This PR is to update static variables in the pipeline to parameters so that when a build is triggered, a value can be selected manually.

Refer below screenshot: for Dev purposes sign type can be test but for production releases it can be real with M2 approval. 

<img width="960" alt="image" src="https://user-images.githubusercontent.com/105889062/211568447-47f902ab-3709-4624-b88d-fca4e63c3889.png">
