### PR TITLE
Update azure-pipelines.yml for Azure Pipelines

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -97,12 +97,12 @@ jobs:
     name: ''
     displayName: Install Signing Plugin
     enabled: True
-    condition: eq(parameters.SignTypeToUse, 'real')
+    condition: eq(${{ parameters.SignTypeToUse }}, 'real')
     inputs:
       signType: ${{ parameters.SignTypeToUse }}
       zipSources: false
   - task: MicroBuildLocalizationPlugin@3
-    condition: eq(parameters.SignTypeToUse, 'real')
+    condition: eq(${{ parameters.SignTypeToUse }}, 'real')
     displayName: 'Install Localization Plugin'
     enabled: True
   - task: UseDotNet@2
@@ -272,7 +272,7 @@ jobs:
     name: ''
     displayName: Sign Files
     enabled: True
-    condition: eq(parameters.SignTypeToUse, 'real')
+    condition: eq(${{ parameters.SignTypeToUse }}, 'real')
     inputs:
       solution: src/client.signproj
       msbuildArgs: /t:SignFiles /p:SignType=${{ parameters.SignTypeToUse }}
@@ -563,12 +563,12 @@ jobs:
   - task: MicroBuildSigningPlugin@3
     displayName: Install Signing Plugin
     enabled: True
-    condition: eq(parameters.SignTypeToUse, 'real')
+    condition: eq(${{ parameters.SignTypeToUse }}, 'real')
     inputs:
       signType: ${{ parameters.SignTypeToUse }}
       zipSources: false
   - task: MicroBuildLocalizationPlugin@3
-    condition: eq(parameters.SignTypeToUse, 'real')
+    condition: eq(${{ parameters.SignTypeToUse }}, 'real')
     displayName: Install Localization Plugin
   - task: UseDotNet@2
     displayName: Use .NET Core SDK 6.0.X
@@ -672,7 +672,7 @@ jobs:
   - task: VSBuild@1
     displayName: Sign Files
     enabled: True
-    condition: eq(parameters.SignTypeToUse, 'real')
+    condition: eq(${{ parameters.SignTypeToUse }}, 'real')
     inputs:
       solution: src/client.signproj
       msbuildArgs: /t:SignFiles /p:SignType=${{ parameters.SignTypeToUse }}

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -78,9 +78,6 @@ jobs:
             Write-Host "Done setting the sign type and telemetry key instance for main branch"
         }
 
-
-        Write-Host "Disabling NuGet package signing because it doesn't work, and we don't publish public NuGet packages"
-
         Write-Host "##vso[task.setvariable variable=MicroBuild_NuPkgSigningEnabled]true"
   - task: MicroBuildSigningPlugin@3
     name: ''
@@ -542,8 +539,6 @@ jobs:
             Write-Host "##vso[task.setvariable variable=TelemetryType]"{{ parameters.TelemetryType }}
             Write-Host "Done setting the sign type and telemetry key instance for staging branch"
         }
-
-        Write-Host "Disabling NuGet package signing because it doesn't work, and we don't publish public NuGet packages"
 
         Write-Host "##vso[task.setvariable variable=MicroBuild_NuPkgSigningEnabled]true"
   - task: MicroBuildSigningPlugin@3

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -97,12 +97,12 @@ jobs:
     name: ''
     displayName: Install Signing Plugin
     enabled: True
-    condition: eq(${{ parameters.SignTypeToUse }}, 'real')
+    condition: eq('${{ parameters.SignTypeToUse }}', 'real')
     inputs:
       signType: ${{ parameters.SignTypeToUse }}
       zipSources: false
   - task: MicroBuildLocalizationPlugin@3
-    condition: eq(${{ parameters.SignTypeToUse }}, 'real')
+    condition: eq('${{ parameters.SignTypeToUse }}', 'real')
     displayName: 'Install Localization Plugin'
     enabled: True
   - task: UseDotNet@2
@@ -272,7 +272,7 @@ jobs:
     name: ''
     displayName: Sign Files
     enabled: True
-    condition: eq(${{ parameters.SignTypeToUse }}, 'real')
+    condition: eq('${{ parameters.SignTypeToUse }}', 'real')
     inputs:
       solution: src/client.signproj
       msbuildArgs: /t:SignFiles /p:SignType=${{ parameters.SignTypeToUse }}
@@ -563,12 +563,12 @@ jobs:
   - task: MicroBuildSigningPlugin@3
     displayName: Install Signing Plugin
     enabled: True
-    condition: eq(${{ parameters.SignTypeToUse }}, 'real')
+    condition: eq('${{ parameters.SignTypeToUse }}', 'real')
     inputs:
       signType: ${{ parameters.SignTypeToUse }}
       zipSources: false
   - task: MicroBuildLocalizationPlugin@3
-    condition: eq(${{ parameters.SignTypeToUse }}, 'real')
+    condition: eq('${{ parameters.SignTypeToUse }}', 'real')
     displayName: Install Localization Plugin
   - task: UseDotNet@2
     displayName: Use .NET Core SDK 6.0.X
@@ -672,7 +672,7 @@ jobs:
   - task: VSBuild@1
     displayName: Sign Files
     enabled: True
-    condition: eq(${{ parameters.SignTypeToUse }}, 'real')
+    condition: eq('${{ parameters.SignTypeToUse }}', 'real')
     inputs:
       solution: src/client.signproj
       msbuildArgs: /t:SignFiles /p:SignType=${{ parameters.SignTypeToUse }}

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -14,12 +14,6 @@
 # Variable 'TeamName' was defined in the Variables tab
 # Variable 'TelemetryType' was defined in the Variables tab
 parameters:
-  - name: SignTypeToUse
-    displayName: Signing Type
-    default: 'test'
-    values:
-    - test
-    - real
   - name: TelemetryType
     displayName: Telemetry Type so that correct application insights key is selected
     default: 'TELEMETRY_DEVELOPMENT'
@@ -87,17 +81,15 @@ jobs:
 
         Write-Host "Disabling NuGet package signing because it doesn't work, and we don't publish public NuGet packages"
 
-        Write-Host "##vso[task.setvariable variable=MicroBuild_NuPkgSigningEnabled]false"
+        Write-Host "##vso[task.setvariable variable=MicroBuild_NuPkgSigningEnabled]true"
   - task: MicroBuildSigningPlugin@3
     name: ''
     displayName: Install Signing Plugin
     enabled: True
-    condition: eq('${{ parameters.SignTypeToUse }}', 'real')
     inputs:
-      signType: ${{ parameters.SignTypeToUse }}
+      signType: real
       zipSources: false
   - task: MicroBuildLocalizationPlugin@3
-    condition: eq('${{ parameters.SignTypeToUse }}', 'real')
     displayName: 'Install Localization Plugin'
     enabled: True
   - task: UseDotNet@2
@@ -267,10 +259,9 @@ jobs:
     name: ''
     displayName: Sign Files
     enabled: True
-    condition: eq('${{ parameters.SignTypeToUse }}', 'real')
     inputs:
       solution: src/client.signproj
-      msbuildArgs: /t:SignFiles /p:SignType=${{ parameters.SignTypeToUse }}
+      msbuildArgs: /t:SignFiles /p:SignType=real
       configuration: '${{ parameters.BuildConfiguration }} '
   - task: CopyFiles@2
     displayName: Collect files for .zip (Windows)
@@ -554,16 +545,14 @@ jobs:
 
         Write-Host "Disabling NuGet package signing because it doesn't work, and we don't publish public NuGet packages"
 
-        Write-Host "##vso[task.setvariable variable=MicroBuild_NuPkgSigningEnabled]false"
+        Write-Host "##vso[task.setvariable variable=MicroBuild_NuPkgSigningEnabled]true"
   - task: MicroBuildSigningPlugin@3
     displayName: Install Signing Plugin
     enabled: True
-    condition: eq('${{ parameters.SignTypeToUse }}', 'real')
     inputs:
-      signType: ${{ parameters.SignTypeToUse }}
+      signType: real
       zipSources: false
   - task: MicroBuildLocalizationPlugin@3
-    condition: eq('${{ parameters.SignTypeToUse }}', 'real')
     displayName: Install Localization Plugin
   - task: UseDotNet@2
     displayName: Use .NET Core SDK 6.0.X
@@ -667,10 +656,9 @@ jobs:
   - task: VSBuild@1
     displayName: Sign Files
     enabled: True
-    condition: eq('${{ parameters.SignTypeToUse }}', 'real')
     inputs:
       solution: src/client.signproj
-      msbuildArgs: /t:SignFiles /p:SignType=${{ parameters.SignTypeToUse }}
+      msbuildArgs: /t:SignFiles /p:SignType=real
       configuration: '${{ parameters.BuildConfiguration }} '
   - task: CopyFiles@2
     displayName: Collect files for .zip (Windows)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -97,10 +97,12 @@ jobs:
     name: ''
     displayName: Install Signing Plugin
     enabled: True
+    condition: eq(parameters.SignTypeToUse, 'real')
     inputs:
       signType: ${{ parameters.SignTypeToUse }}
       zipSources: false
   - task: MicroBuildLocalizationPlugin@3
+    condition: eq(parameters.SignTypeToUse, 'real')
     displayName: 'Install Localization Plugin'
     enabled: True
   - task: UseDotNet@2
@@ -270,6 +272,7 @@ jobs:
     name: ''
     displayName: Sign Files
     enabled: True
+    condition: eq(parameters.SignTypeToUse, 'real')
     inputs:
       solution: src/client.signproj
       msbuildArgs: /t:SignFiles /p:SignType=${{ parameters.SignTypeToUse }}
@@ -560,10 +563,12 @@ jobs:
   - task: MicroBuildSigningPlugin@3
     displayName: Install Signing Plugin
     enabled: True
+    condition: eq(parameters.SignTypeToUse, 'real')
     inputs:
       signType: ${{ parameters.SignTypeToUse }}
       zipSources: false
   - task: MicroBuildLocalizationPlugin@3
+    condition: eq(parameters.SignTypeToUse, 'real')
     displayName: Install Localization Plugin
   - task: UseDotNet@2
     displayName: Use .NET Core SDK 6.0.X
@@ -667,6 +672,7 @@ jobs:
   - task: VSBuild@1
     displayName: Sign Files
     enabled: True
+    condition: eq(parameters.SignTypeToUse, 'real')
     inputs:
       solution: src/client.signproj
       msbuildArgs: /t:SignFiles /p:SignType=${{ parameters.SignTypeToUse }}

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -43,11 +43,6 @@ variables:
 - name: RunTests
   value: True
 
-trigger:
-  branches:
-    include:
-    - refs/heads/main
-  batch: True
 name: $(date:yyyyMMdd)$(rev:.r)
 resources:
   repositories:


### PR DESCRIPTION
What this PR does: If PR triggered pipeline (sign type test), then we will exclude all the signing tasks. 

This is first step to splitting pipelines into two. One build pipeline for PRs and one build pipeline for release (this will be a clone of build pipelines + signing). This second pipeline will remain internal (not github exposed) and this way we can ensure that sign build will only run on main and started by Bridge team members.