### PR TITLE
Fix dotnet pack to include build configuration

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -473,7 +473,7 @@ jobs:
       packagesToPack: src/dsc/dsc.csproj
       packDirectory: '$(Build.ArtifactStagingDirectory)/nuget'
       nobuild: true
-      buildProperties: 'NuspecFile=bin\${{ parameters.BuildConfiguration }}\net6.0\win-x64\publish\dsc.nuspec'
+      buildProperties: 'Configuration=${{ parameters.BuildConfiguration }};NuspecFile=bin\${{ parameters.BuildConfiguration }}\net6.0\win-x64\publish\dsc.nuspec'
   - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
     displayName: 'Manifest Generator for nuget'
     inputs:


### PR DESCRIPTION
[This commit](https://github.com/Azure/Bridge-To-Kubernetes/commit/12c88bfe897402d3ea2dd6438b3b7861eb9d4871#diff-7915b9b726a397ae7ba6af7b9703633d21c031ebf21682f3ee7e6a4ec52837a5) removed configuration from being passed to donet pack command. This leads to nuget version to be wrong (version-cloudttest instead of just version). Which leads to VS extension to not be able to find the nuget package. This PR adds build configuration.