### PR TITLE
Named Port Environment Variables

### DIFF
--- a/src/all.sln
+++ b/src/all.sln
@@ -33,9 +33,9 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "devhostAgent.restorationjob
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "routingmanager.tests", "routingmanager.tests\routingmanager.tests.csproj", "{49DF73FE-1E7D-4AF6-87B5-194BF4A35ADB}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "endpointmanagerlauncher", "endpointmanagerlauncher\endpointmanagerlauncher.csproj", "{B406D9B1-35B1-42CC-B39C-9E6E691EB99E}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "endpointmanagerlauncher", "EndpointManagerLauncher\endpointmanagerlauncher.csproj", "{B406D9B1-35B1-42CC-B39C-9E6E691EB99E}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "localagent", "LocalAgent\localagent.csproj", "{C3F0EE30-9187-43D8-B2C7-86CD61635561}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "localagent", "LocalAgent\LocalAgent.csproj", "{C3F0EE30-9187-43D8-B2C7-86CD61635561}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "dsc.tests", "dsc.tests\dsc.tests.csproj", "{C3753974-9857-4AF1-B06B-DD53F963108B}"
 EndProject

--- a/src/common/Kubernetes/KubernetesConstants.cs
+++ b/src/common/Kubernetes/KubernetesConstants.cs
@@ -70,7 +70,7 @@ namespace Microsoft.BridgeToKubernetes.Common.Kubernetes
 
         public static class Protocols
         {
-            public const string Tcp = "TCP";
+            public const string Tcp = "tcp";
         }
     }
 }

--- a/src/common/Models/Settings/PortPair.cs
+++ b/src/common/Models/Settings/PortPair.cs
@@ -20,12 +20,14 @@ namespace Microsoft.BridgeToKubernetes.Common.Models.Settings
         /// <param name="localPort"></param>
         /// <param name="remotePort"></param>
         /// <param name="protocol"></param>
+        /// <param name="name"></param>
         [JsonConstructor]
-        public PortPair(int localPort, int remotePort, string protocol = KubernetesConstants.Protocols.Tcp)
+        public PortPair(int localPort, int remotePort, string protocol = KubernetesConstants.Protocols.Tcp, string name = null)
         {
-            this.LocalPort = localPort;
-            this.RemotePort = remotePort;
-            this.Protocol = protocol;
+            LocalPort = localPort;
+            RemotePort = remotePort;
+            Protocol = protocol;
+            Name = name;
         }
 
         /// <summary>
@@ -33,11 +35,13 @@ namespace Microsoft.BridgeToKubernetes.Common.Models.Settings
         /// </summary>
         /// <param name="remotePort"></param>
         /// <param name="protocol"></param>
-        public PortPair(int remotePort, string protocol = KubernetesConstants.Protocols.Tcp)
+        /// <param name="name"></param>
+        public PortPair(int remotePort, string protocol = KubernetesConstants.Protocols.Tcp, string name = null)
         {
-            this.LocalPort = Constants.IP.PortPlaceHolder;
-            this.RemotePort = remotePort;
-            this.Protocol = protocol;
+            LocalPort = Constants.IP.PortPlaceHolder;
+            RemotePort = remotePort;
+            Protocol = protocol;
+            Name = name;
         }
 
         /// <summary>
@@ -53,10 +57,20 @@ namespace Microsoft.BridgeToKubernetes.Common.Models.Settings
         public int RemotePort { get; set; }
 
         /// <summary>
-        /// Procol used when comunicating on this port (usually TCP)
+        /// Protocol used when communicating on this port (usually TCP)
         /// </summary>
         [JsonProperty("protocol")]
         public string Protocol { get; set; }
+
+        /// <summary>
+        /// Name metadata corresponding to named ports in service resource in Kubernetes
+        /// </summary>
+        /// <remarks>
+        /// Service resources with multiple ports must be given names so that they are unambiguous.
+        /// https://kubernetes.io/docs/concepts/services-networking/service/#multi-port-services
+        /// </remarks>
+        [JsonProperty("name")]
+        public string Name { get; set; }
 
         /// <summary>
         /// Create a clone of this object
@@ -64,7 +78,7 @@ namespace Microsoft.BridgeToKubernetes.Common.Models.Settings
         /// <returns></returns>
         public object Clone()
         {
-            return new PortPair(LocalPort, RemotePort, Protocol);
+            return new PortPair(LocalPort, RemotePort, Protocol, Name);
         }
     }
 }


### PR DESCRIPTION
Kubernetes used to have an environment variable of `{serviceName}_SERVICE_PORT_{protocol}`, however, this has since been replaced with a better mechanism for tracking services that contain multiple port mappings using name metadata to keep the ports unambiguous.

> When using multiple ports for a Service, you must give all of your ports names so that these are unambiguous.
https://kubernetes.io/docs/concepts/services-networking/service/#multi-port-services

Issue: https://github.com/Azure/Bridge-To-Kubernetes/issues/165

Whilst I have refactored the unit tests for the library code and they are passing, I have not yet looked into actually testing this out in VSCode, I am assuming there are instructions to do this somewhere or can someone try it for me?