### PR TITLE
RefreshCredentialsAsync was missing a SetSucceeded for perf logger

### DIFF
--- a/src/library/Client/ManagementClients/KubernetesManagementClient.cs
+++ b/src/library/Client/ManagementClients/KubernetesManagementClient.cs
@@ -98,6 +98,7 @@ namespace Microsoft.BridgeToKubernetes.Library.Client.ManagementClients
                         {
                             // If we are able to list pods using the the KubernetesClient everything is cool
                             var po = await _kubernetesClient.ListPodsInNamespaceAsync(targetNamespace);
+                            perfLogger.SetSucceeded();
                             return;
                         }
                         catch (k8s.Exceptions.KubeConfigException ex)


### PR DESCRIPTION
When investigating [this issue](https://github.com/Azure/Bridge-To-Kubernetes/issues/158) I noticed that result of refreshcredentials was only set to false because we were missing a set succeeded on the perflogger, but it was exiting on the happy path.