### PR TITLE
Add catch around Delete Service invocation

### DIFF
--- a/samples/managed-identity/.vscode/tasks.json
+++ b/samples/managed-identity/.vscode/tasks.json
@@ -39,19 +39,22 @@
             "problemMatcher": "$msCompile"
         },
         {
-            "label": "bridge-to-kubernetes.service",
-            "type": "bridge-to-kubernetes.service",
-            "service": "mi-webapp-service",
+            "label": "bridge-to-kubernetes.resource",
+            "type": "bridge-to-kubernetes.resource",
+            "resource": "mi-webapp-service",
+            "resourceType": "service",
             "ports": [
                 80
             ],
             "targetCluster": "testing-scenarios",
-            "targetNamespace": "mi-webapp"
+            "targetNamespace": "mi-webapp2",
+            "useKubernetesServiceEnvironmentVariables": false,
+            "isolateAs": "elvilla-d987"
         },
         {
             "label": "bridge-to-kubernetes.compound",
             "dependsOn": [
-                "bridge-to-kubernetes.service",
+                "bridge-to-kubernetes.resource",
                 "build"
             ],
             "dependsOrder": "sequence"

--- a/src/common/Kubernetes/KubernetesClient.cs
+++ b/src/common/Kubernetes/KubernetesClient.cs
@@ -401,6 +401,7 @@ namespace Microsoft.BridgeToKubernetes.Common.Kubernetes
                 {
                     try 
                     {
+                        _log.Warning("Initial CreateNamespacedServiceAsync failed, deleting namespace");
                         await RestClient.CoreV1.DeleteNamespacedServiceAsync(service.Metadata.Name, namespaceName);
                     }
                     catch (JsonException ex)

--- a/src/common/Kubernetes/KubernetesClient.cs
+++ b/src/common/Kubernetes/KubernetesClient.cs
@@ -12,6 +12,7 @@ using System.Net.Http;
 using System.Net.Sockets;
 using System.Net.WebSockets;
 using System.Text;
+using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using k8s;
@@ -398,8 +399,20 @@ namespace Microsoft.BridgeToKubernetes.Common.Kubernetes
                 }
                 catch (HttpOperationException e) when (e.Response.StatusCode == HttpStatusCode.Conflict)
                 {
-                    await RestClient.CoreV1.DeleteNamespacedServiceAsync(service.Metadata.Name, namespaceName);
+                    try 
+                    {
+                        await RestClient.CoreV1.DeleteNamespacedServiceAsync(service.Metadata.Name, namespaceName);
+                    }
+                    catch (JsonException ex)
+                    {
+                        // Delete service can through Json error when kubernetes server and client version are incompatible:
+                        // 1.21 and 1.22 DeleteService returns v1.Status (6.0 client sdk)
+                        // while in 1.23, DeleteService returns v1.Service (7.0+ client sdk)
+                        // more details on this issue: https://github.com/kubernetes-client/csharp/issues/824
+                        _log.Exception(ex);
+                    }
                     return await RestClient.CoreV1.CreateNamespacedServiceAsync(service, namespaceName, cancellationToken: cancellationToken);
+
                 }
             }, nameof(CreateOrReplaceV1ServiceAsync), cancellationToken);
         }


### PR DESCRIPTION
there is breaking changes between different version of kubernetes if client and server diverge enough. 1.21 and 1.22 DeleteService returns v1.Status (6.0 client sdk) while in 1.23, DeleteService returns v1.Service (7.0+ client sdk). [Related issue](https://github.com/kubernetes-client/csharp/issues/824)  with more details. We can control the client since it comes with bridge code (aka c# library), but we cannot control the server aka kubernetes version in the cluster. Thus exception handling is needed. 

This will solve #90 and #55 