### PR TITLE
Add signing validation to our official build pipeline

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -551,12 +551,12 @@ jobs:
         }
 
         Write-Host "##vso[task.setvariable variable=MicroBuild_NuPkgSigningEnabled;]true"
-  #- task: MicroBuildSigningPlugin@3
-  #  displayName: Install Signing Plugin
-  #  enabled: True
-  #  inputs:
-  #    signType: real
-  #    zipSources: false
+  - task: MicroBuildSigningPlugin@3
+    displayName: Install Signing Plugin
+    enabled: True
+    inputs:
+      signType: real
+      zipSources: false
   - task: MicroBuildLocalizationPlugin@3
     displayName: Install Localization Plugin
   - task: UseDotNet@2
@@ -658,13 +658,13 @@ jobs:
         New-Item -Path '$(Build.SourcesDirectory)/src/dsc/bin/${{ parameters.BuildConfiguration }}/net6.0/linux-x64/publish/kubectl/linux' -ItemType Directory
 
         curl https://dl.k8s.io/release/v1.21.2/bin/linux/amd64/kubectl  -OutFile $(Build.SourcesDirectory)/src/dsc/bin/${{ parameters.BuildConfiguration }}/net6.0/linux-x64/publish/kubectl/linux/kubectl
-  - task: VSBuild@1
-    displayName: Sign Files
-    enabled: True
-    inputs:
-      solution: src/client.signproj
-      msbuildArgs: /t:SignFiles /p:SignType=real
-      configuration: '${{ parameters.BuildConfiguration }} '
+  #- task: VSBuild@1
+  #  displayName: Sign Files
+  #  enabled: True
+  #  inputs:
+  #    solution: src/client.signproj
+  #    msbuildArgs: /t:SignFiles /p:SignType=real
+  #    configuration: '${{ parameters.BuildConfiguration }} '
   - task: CopyFiles@2
     displayName: Collect files for .zip (Windows)
     inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -819,7 +819,6 @@ jobs:
     displayName: Validate Signatures linux
     inputs:
       Path: '$(Agent.TempDirectory)/zip/linux'
-      continueOnError: false
   - task: ArchiveFiles@2
     displayName: Create .zip file (Windows)
     inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -264,6 +264,7 @@ jobs:
       msbuildArgs: /t:SignFiles /p:SignType=real
       configuration: '${{ parameters.BuildConfiguration }} '
   - task: CodeSign@1
+    displayName: Validate Signatures
     inputs:
       Path: 'src/dsc/bin/${{ parameters.BuildConfiguration }}/net6.0/win-x64/publish'
   - task: CopyFiles@2
@@ -664,6 +665,10 @@ jobs:
       solution: src/client.signproj
       msbuildArgs: /t:SignFiles /p:SignType=real
       configuration: '${{ parameters.BuildConfiguration }} '
+  - task: CodeSign@1
+    displayName: Validate Signatures
+    inputs:
+      Path: 'src/dsc/bin/${{ parameters.BuildConfiguration }}/net6.0/win-x64/publish'
   - task: CopyFiles@2
     displayName: Collect files for .zip (Windows)
     inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -255,14 +255,14 @@ jobs:
         New-Item -Path './src/dsc/bin/${{ parameters.BuildConfiguration }}/net6.0/linux-x64/publish/kubectl/linux' -ItemType Directory
 
         curl https://dl.k8s.io/release/v1.21.2/bin/linux/amd64/kubectl  -OutFile ./src/dsc/bin/${{ parameters.BuildConfiguration }}/net6.0/linux-x64/publish/kubectl/linux/kubectl
-  #- task: VSBuild@1
-  #  name: ''
-  #  displayName: Sign Files
-  #  enabled: True
-  #  inputs:
-  #    solution: src/client.signproj
-  #    msbuildArgs: /t:SignFiles /p:SignType=real
-  #    configuration: '${{ parameters.BuildConfiguration }} '
+  - task: VSBuild@1
+    name: ''
+    displayName: Sign Files
+    enabled: True
+    inputs:
+      solution: src/client.signproj
+      msbuildArgs: /t:SignFiles /p:SignType=real
+      configuration: '${{ parameters.BuildConfiguration }} '
   - task: CopyFiles@2
     displayName: Collect files for .zip (Windows)
     enabled: True
@@ -473,7 +473,7 @@ jobs:
       PathtoPublish: '$(Build.ArtifactStagingDirectory)/nuget'
       ArtifactName: nuget
   - task: CodeSign@1
-    displayName: Validate Signatures
+    displayName: Validate Signatures nuget
     inputs:
       Path: '$(Build.ArtifactStagingDirectory)/nuget'
   - task: CopyFiles@2
@@ -524,6 +524,7 @@ jobs:
   - task: SdtReport@2
     inputs:
       GdnExportAllTools: true
+      GdnExportHtmlFile: true
   - task: PublishSecurityAnalysisLogs@3
     inputs:
       ArtifactName: 'CodeAnalysisLogs'
@@ -673,13 +674,13 @@ jobs:
         New-Item -Path '$(Build.SourcesDirectory)/src/dsc/bin/${{ parameters.BuildConfiguration }}/net6.0/linux-x64/publish/kubectl/linux' -ItemType Directory
 
         curl https://dl.k8s.io/release/v1.21.2/bin/linux/amd64/kubectl  -OutFile $(Build.SourcesDirectory)/src/dsc/bin/${{ parameters.BuildConfiguration }}/net6.0/linux-x64/publish/kubectl/linux/kubectl
-  #- task: VSBuild@1
-  #  displayName: Sign Files
-  #  enabled: True
-  #  inputs:
-  #    solution: src/client.signproj
-  #    msbuildArgs: /t:SignFiles /p:SignType=real
-  #    configuration: '${{ parameters.BuildConfiguration }} '
+  - task: VSBuild@1
+    displayName: Sign Files
+    enabled: True
+    inputs:
+      solution: src/client.signproj
+      msbuildArgs: /t:SignFiles /p:SignType=real
+      configuration: '${{ parameters.BuildConfiguration }} '
   - task: CopyFiles@2
     displayName: Collect files for .zip (Windows)
     inputs:
@@ -766,6 +767,10 @@ jobs:
 
         !**/zh-Hant/*
       TargetFolder: $(Agent.TempDirectory)/zip/osx
+  - task: CodeSign@1
+    displayName: Validate Signatures OSX
+    inputs:
+      Path: '$(Agent.TempDirectory)/zip/osx'
   - task: CopyFiles@2
     displayName: Collect files for .zip (Linux)
     inputs:
@@ -809,6 +814,10 @@ jobs:
 
         !**/zh-Hant/*
       TargetFolder: $(Agent.TempDirectory)/zip/linux
+  - task: CodeSign@1
+    displayName: Validate Signatures linux
+    inputs:
+      Path: '$(Agent.TempDirectory)/zip/linux'
   - task: ArchiveFiles@2
     displayName: Create .zip file (Windows)
     inputs:
@@ -901,6 +910,7 @@ jobs:
   - task: SdtReport@2
     inputs:
       GdnExportAllTools: true
+      GdnExportHtmlFile: true
   - task: PublishSecurityAnalysisLogs@3
     inputs:
       ArtifactName: 'CodeAnalysisLogs'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -520,6 +520,16 @@ jobs:
     enabled: True
     inputs:
       tags: 'BuildConfiguration: ${{ parameters.BuildConfiguration }}'
+
+  - task: SdtReport@2
+    inputs:
+      GdnExportAllTools: true
+  - task: PublishSecurityAnalysisLogs@3
+    inputs:
+      ArtifactName: 'CodeAnalysisLogs'
+      ArtifactType: 'Container'
+      AllTools: true
+      ToolLogsNotFoundAction: 'Standard'
   - task: PostAnalysis@2
     inputs:
       GdnBreakAllTools: true
@@ -887,6 +897,16 @@ jobs:
     inputs:
       PathtoPublish: $(Build.ArtifactStagingDirectory)/zip
       ArtifactName: zipv2
+
+  - task: SdtReport@2
+    inputs:
+      GdnExportAllTools: true
+  - task: PublishSecurityAnalysisLogs@3
+    inputs:
+      ArtifactName: 'CodeAnalysisLogs'
+      ArtifactType: 'Container'
+      AllTools: true
+      ToolLogsNotFoundAction: 'Standard'
   - task: PostAnalysis@2
     inputs:
       GdnBreakAllTools: true

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -263,6 +263,9 @@ jobs:
       solution: src/client.signproj
       msbuildArgs: /t:SignFiles /p:SignType=real
       configuration: '${{ parameters.BuildConfiguration }} '
+  - task: CodeSign@1
+    inputs:
+      Path: 'src/dsc/bin/${{ parameters.BuildConfiguration }}/net6.0/win-x64/publish'
   - task: CopyFiles@2
     displayName: Collect files for .zip (Windows)
     enabled: True

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -255,14 +255,14 @@ jobs:
         New-Item -Path './src/dsc/bin/${{ parameters.BuildConfiguration }}/net6.0/linux-x64/publish/kubectl/linux' -ItemType Directory
 
         curl https://dl.k8s.io/release/v1.21.2/bin/linux/amd64/kubectl  -OutFile ./src/dsc/bin/${{ parameters.BuildConfiguration }}/net6.0/linux-x64/publish/kubectl/linux/kubectl
-  - task: VSBuild@1
-    name: ''
-    displayName: Sign Files
-    enabled: True
-    inputs:
-      solution: src/client.signproj
-      msbuildArgs: /t:SignFiles /p:SignType=real
-      configuration: '${{ parameters.BuildConfiguration }} '
+  #- task: VSBuild@1
+  #  name: ''
+  #  displayName: Sign Files
+  #  enabled: True
+  #  inputs:
+  #    solution: src/client.signproj
+  #    msbuildArgs: /t:SignFiles /p:SignType=real
+  #    configuration: '${{ parameters.BuildConfiguration }} '
   - task: CopyFiles@2
     displayName: Collect files for .zip (Windows)
     enabled: True
@@ -520,6 +520,11 @@ jobs:
     enabled: True
     inputs:
       tags: 'BuildConfiguration: ${{ parameters.BuildConfiguration }}'
+  - task: PostAnalysis@2
+    inputs:
+      GdnBreakAllTools: true
+      GdnBreakFast: true
+
 - job: Phase_2
   displayName: Run NON self-contained build (binaries V2, where the binaries are downloaded in parallel)
   timeoutInMinutes: 120
@@ -882,4 +887,8 @@ jobs:
     inputs:
       PathtoPublish: $(Build.ArtifactStagingDirectory)/zip
       ArtifactName: zipv2
+  - task: PostAnalysis@2
+    inputs:
+      GdnBreakAllTools: true
+      GdnBreakFast: true
 ...

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -476,7 +476,6 @@ jobs:
     displayName: Validate Signatures nuget
     inputs:
       Path: '$(Build.ArtifactStagingDirectory)/nuget'
-      continueOnError: false
   - task: CopyFiles@2
     displayName: Collect Build Symbols - dsc
     enabled: True

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -523,8 +523,9 @@ jobs:
 
   - task: SdtReport@2
     inputs:
-      GdnExportAllTools: true
+      GdnExportAllTools: false
       GdnExportHtmlFile: true
+      GdnExportGdnToolCodesignValidationSeverity: Warning
   - task: PublishSecurityAnalysisLogs@3
     inputs:
       ArtifactName: 'CodeAnalysisLogs'
@@ -909,8 +910,9 @@ jobs:
 
   - task: SdtReport@2
     inputs:
-      GdnExportAllTools: true
+      GdnExportAllTools: false
       GdnExportHtmlFile: true
+      GdnExportGdnToolCodesignValidationSeverity: Warning
   - task: PublishSecurityAnalysisLogs@3
     inputs:
       ArtifactName: 'CodeAnalysisLogs'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -551,12 +551,12 @@ jobs:
         }
 
         Write-Host "##vso[task.setvariable variable=MicroBuild_NuPkgSigningEnabled;]true"
-  - task: MicroBuildSigningPlugin@3
-    displayName: Install Signing Plugin
-    enabled: True
-    inputs:
-      signType: real
-      zipSources: false
+  #- task: MicroBuildSigningPlugin@3
+  #  displayName: Install Signing Plugin
+  #  enabled: True
+  #  inputs:
+  #    signType: real
+  #    zipSources: false
   - task: MicroBuildLocalizationPlugin@3
     displayName: Install Localization Plugin
   - task: UseDotNet@2

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -255,14 +255,14 @@ jobs:
         New-Item -Path './src/dsc/bin/${{ parameters.BuildConfiguration }}/net6.0/linux-x64/publish/kubectl/linux' -ItemType Directory
 
         curl https://dl.k8s.io/release/v1.21.2/bin/linux/amd64/kubectl  -OutFile ./src/dsc/bin/${{ parameters.BuildConfiguration }}/net6.0/linux-x64/publish/kubectl/linux/kubectl
-  #- task: VSBuild@1
-  #  name: ''
-  #  displayName: Sign Files
-  #  enabled: True
-  #  inputs:
-  #    solution: src/client.signproj
-  #    msbuildArgs: /t:SignFiles /p:SignType=real
-  #    configuration: '${{ parameters.BuildConfiguration }} '
+  - task: VSBuild@1
+    name: ''
+    displayName: Sign Files
+    enabled: True
+    inputs:
+      solution: src/client.signproj
+      msbuildArgs: /t:SignFiles /p:SignType=real
+      configuration: '${{ parameters.BuildConfiguration }} '
   - task: CopyFiles@2
     displayName: Collect files for .zip (Windows)
     enabled: True
@@ -522,20 +522,20 @@ jobs:
     inputs:
       tags: 'BuildConfiguration: ${{ parameters.BuildConfiguration }}'
 
-  #- task: SdtReport@2
-  #  inputs:
-  #    GdnExportAllTools: true
-  #    GdnExportHtmlFile: true
-  #- task: PublishSecurityAnalysisLogs@3
-  #  inputs:
-  #    ArtifactName: 'CodeAnalysisLogs'
-  #    ArtifactType: 'Container'
-  #    AllTools: true
-  #    ToolLogsNotFoundAction: 'Standard'
-  #- task: PostAnalysis@2
-  #  inputs:
-  #    GdnBreakAllTools: true
-  #    GdnBreakFast: true
+  - task: SdtReport@2
+    inputs:
+      GdnExportAllTools: true
+      GdnExportHtmlFile: true
+  - task: PublishSecurityAnalysisLogs@3
+    inputs:
+      ArtifactName: 'CodeAnalysisLogs'
+      ArtifactType: 'Container'
+      AllTools: true
+      ToolLogsNotFoundAction: 'Standard'
+  - task: PostAnalysis@2
+    inputs:
+      GdnBreakAllTools: true
+      GdnBreakFast: true
 
 - job: Phase_2
   displayName: Run NON self-contained build (binaries V2, where the binaries are downloaded in parallel)
@@ -675,13 +675,13 @@ jobs:
         New-Item -Path '$(Build.SourcesDirectory)/src/dsc/bin/${{ parameters.BuildConfiguration }}/net6.0/linux-x64/publish/kubectl/linux' -ItemType Directory
 
         curl https://dl.k8s.io/release/v1.21.2/bin/linux/amd64/kubectl  -OutFile $(Build.SourcesDirectory)/src/dsc/bin/${{ parameters.BuildConfiguration }}/net6.0/linux-x64/publish/kubectl/linux/kubectl
-  #- task: VSBuild@1
-  #  displayName: Sign Files
-  #  enabled: True
-  #  inputs:
-  #    solution: src/client.signproj
-  #    msbuildArgs: /t:SignFiles /p:SignType=real
-  #    configuration: '${{ parameters.BuildConfiguration }} '
+  - task: VSBuild@1
+    displayName: Sign Files
+    enabled: True
+    inputs:
+      solution: src/client.signproj
+      msbuildArgs: /t:SignFiles /p:SignType=real
+      configuration: '${{ parameters.BuildConfiguration }} '
   - task: CopyFiles@2
     displayName: Collect files for .zip (Windows)
     inputs:
@@ -725,7 +725,6 @@ jobs:
     displayName: Validate Signatures
     inputs:
       Path: '$(Agent.TempDirectory)/zip/win'
-      continueOnError: false
   - task: CopyFiles@2
     displayName: Collect files for .zip (OSX)
     inputs:
@@ -773,7 +772,6 @@ jobs:
     displayName: Validate Signatures OSX
     inputs:
       Path: '$(Agent.TempDirectory)/zip/osx'
-      continueOnError: false
   - task: CopyFiles@2
     displayName: Collect files for .zip (Linux)
     inputs:
@@ -911,18 +909,18 @@ jobs:
       PathtoPublish: $(Build.ArtifactStagingDirectory)/zip
       ArtifactName: zipv2
 
-  #- task: SdtReport@2
-  #  inputs:
-  #    GdnExportAllTools: true
-  #    GdnExportHtmlFile: true
-  #- task: PublishSecurityAnalysisLogs@3
-  #  inputs:
-  #    ArtifactName: 'CodeAnalysisLogs'
-  #    ArtifactType: 'Container'
-  #    AllTools: true
-  #    ToolLogsNotFoundAction: 'Standard'
-  #- task: PostAnalysis@2
-  #  inputs:
-  #    GdnBreakAllTools: true
-  #    GdnBreakFast: true
+  - task: SdtReport@2
+    inputs:
+      GdnExportAllTools: true
+      GdnExportHtmlFile: true
+  - task: PublishSecurityAnalysisLogs@3
+    inputs:
+      ArtifactName: 'CodeAnalysisLogs'
+      ArtifactType: 'Container'
+      AllTools: true
+      ToolLogsNotFoundAction: 'Standard'
+  - task: PostAnalysis@2
+    inputs:
+      GdnBreakAllTools: true
+      GdnBreakFast: true
 ...

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -523,9 +523,8 @@ jobs:
 
   - task: SdtReport@2
     inputs:
-      GdnExportAllTools: false
+      GdnExportAllTools: true
       GdnExportHtmlFile: true
-      GdnExportGdnToolCodesignValidationSeverity: Warning
   - task: PublishSecurityAnalysisLogs@3
     inputs:
       ArtifactName: 'CodeAnalysisLogs'
@@ -910,9 +909,8 @@ jobs:
 
   - task: SdtReport@2
     inputs:
-      GdnExportAllTools: false
+      GdnExportAllTools: true
       GdnExportHtmlFile: true
-      GdnExportGdnToolCodesignValidationSeverity: Warning
   - task: PublishSecurityAnalysisLogs@3
     inputs:
       ArtifactName: 'CodeAnalysisLogs'
@@ -921,8 +919,6 @@ jobs:
       ToolLogsNotFoundAction: 'Standard'
   - task: PostAnalysis@2
     inputs:
-      GdnBreakAllTools: false
-      GdnBreakGdnToolCodesignValidation: true
-      GdnBreakGdnToolCodesignValidationSeverity: Error
+      GdnBreakAllTools: true
       GdnBreakFast: true
 ...

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -255,14 +255,14 @@ jobs:
         New-Item -Path './src/dsc/bin/${{ parameters.BuildConfiguration }}/net6.0/linux-x64/publish/kubectl/linux' -ItemType Directory
 
         curl https://dl.k8s.io/release/v1.21.2/bin/linux/amd64/kubectl  -OutFile ./src/dsc/bin/${{ parameters.BuildConfiguration }}/net6.0/linux-x64/publish/kubectl/linux/kubectl
-  #- task: VSBuild@1
-  #  name: ''
-  #  displayName: Sign Files
-  #  enabled: True
-  #  inputs:
-  #    solution: src/client.signproj
-  #    msbuildArgs: /t:SignFiles /p:SignType=real
-  #    configuration: '${{ parameters.BuildConfiguration }} '
+  - task: VSBuild@1
+    name: ''
+    displayName: Sign Files
+    enabled: True
+    inputs:
+      solution: src/client.signproj
+      msbuildArgs: /t:SignFiles /p:SignType=real
+      configuration: '${{ parameters.BuildConfiguration }} '
   - task: CopyFiles@2
     displayName: Collect files for .zip (Windows)
     enabled: True
@@ -674,13 +674,13 @@ jobs:
         New-Item -Path '$(Build.SourcesDirectory)/src/dsc/bin/${{ parameters.BuildConfiguration }}/net6.0/linux-x64/publish/kubectl/linux' -ItemType Directory
 
         curl https://dl.k8s.io/release/v1.21.2/bin/linux/amd64/kubectl  -OutFile $(Build.SourcesDirectory)/src/dsc/bin/${{ parameters.BuildConfiguration }}/net6.0/linux-x64/publish/kubectl/linux/kubectl
-  #- task: VSBuild@1
-    #displayName: Sign Files
-    #enabled: True
-    #inputs:
-    #  solution: src/client.signproj
-    #  msbuildArgs: /t:SignFiles /p:SignType=real
-    #  configuration: '${{ parameters.BuildConfiguration }} '
+  - task: VSBuild@1
+    displayName: Sign Files
+    enabled: True
+    inputs:
+      solution: src/client.signproj
+      msbuildArgs: /t:SignFiles /p:SignType=real
+      configuration: '${{ parameters.BuildConfiguration }} '
   - task: CopyFiles@2
     displayName: Collect files for .zip (Windows)
     inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -263,10 +263,6 @@ jobs:
       solution: src/client.signproj
       msbuildArgs: /t:SignFiles /p:SignType=real
       configuration: '${{ parameters.BuildConfiguration }} '
-  - task: CodeSign@1
-    displayName: Validate Signatures
-    inputs:
-      Path: 'src/dsc/bin/${{ parameters.BuildConfiguration }}/net6.0/win-x64/publish'
   - task: CopyFiles@2
     displayName: Collect files for .zip (Windows)
     enabled: True
@@ -476,6 +472,10 @@ jobs:
     inputs:
       PathtoPublish: '$(Build.ArtifactStagingDirectory)/nuget'
       ArtifactName: nuget
+  - task: CodeSign@1
+    displayName: Validate Signatures
+    inputs:
+      Path: '$(Build.ArtifactStagingDirectory)/nuget'
   - task: CopyFiles@2
     displayName: Collect Build Symbols - dsc
     enabled: True
@@ -665,10 +665,6 @@ jobs:
       solution: src/client.signproj
       msbuildArgs: /t:SignFiles /p:SignType=real
       configuration: '${{ parameters.BuildConfiguration }} '
-  - task: CodeSign@1
-    displayName: Validate Signatures
-    inputs:
-      Path: 'src/dsc/bin/${{ parameters.BuildConfiguration }}/net6.0/win-x64/publish'
   - task: CopyFiles@2
     displayName: Collect files for .zip (Windows)
     inputs:
@@ -708,6 +704,10 @@ jobs:
 
         !**/zh-Hant/*
       TargetFolder: $(Agent.TempDirectory)/zip/win
+  - task: CodeSign@1
+    displayName: Validate Signatures
+    inputs:
+      Path: '$(Agent.TempDirectory)/zip/win'
   - task: CopyFiles@2
     displayName: Collect files for .zip (OSX)
     inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -255,14 +255,14 @@ jobs:
         New-Item -Path './src/dsc/bin/${{ parameters.BuildConfiguration }}/net6.0/linux-x64/publish/kubectl/linux' -ItemType Directory
 
         curl https://dl.k8s.io/release/v1.21.2/bin/linux/amd64/kubectl  -OutFile ./src/dsc/bin/${{ parameters.BuildConfiguration }}/net6.0/linux-x64/publish/kubectl/linux/kubectl
-  - task: VSBuild@1
-    name: ''
-    displayName: Sign Files
-    enabled: True
-    inputs:
-      solution: src/client.signproj
-      msbuildArgs: /t:SignFiles /p:SignType=real
-      configuration: '${{ parameters.BuildConfiguration }} '
+  #- task: VSBuild@1
+  #  name: ''
+  #  displayName: Sign Files
+  #  enabled: True
+  #  inputs:
+  #    solution: src/client.signproj
+  #    msbuildArgs: /t:SignFiles /p:SignType=real
+  #    configuration: '${{ parameters.BuildConfiguration }} '
   - task: CopyFiles@2
     displayName: Collect files for .zip (Windows)
     enabled: True
@@ -476,6 +476,7 @@ jobs:
     displayName: Validate Signatures nuget
     inputs:
       Path: '$(Build.ArtifactStagingDirectory)/nuget'
+      continueOnError: false
   - task: CopyFiles@2
     displayName: Collect Build Symbols - dsc
     enabled: True
@@ -521,20 +522,20 @@ jobs:
     inputs:
       tags: 'BuildConfiguration: ${{ parameters.BuildConfiguration }}'
 
-  - task: SdtReport@2
-    inputs:
-      GdnExportAllTools: true
-      GdnExportHtmlFile: true
-  - task: PublishSecurityAnalysisLogs@3
-    inputs:
-      ArtifactName: 'CodeAnalysisLogs'
-      ArtifactType: 'Container'
-      AllTools: true
-      ToolLogsNotFoundAction: 'Standard'
-  - task: PostAnalysis@2
-    inputs:
-      GdnBreakAllTools: true
-      GdnBreakFast: true
+  #- task: SdtReport@2
+  #  inputs:
+  #    GdnExportAllTools: true
+  #    GdnExportHtmlFile: true
+  #- task: PublishSecurityAnalysisLogs@3
+  #  inputs:
+  #    ArtifactName: 'CodeAnalysisLogs'
+  #    ArtifactType: 'Container'
+  #    AllTools: true
+  #    ToolLogsNotFoundAction: 'Standard'
+  #- task: PostAnalysis@2
+  #  inputs:
+  #    GdnBreakAllTools: true
+  #    GdnBreakFast: true
 
 - job: Phase_2
   displayName: Run NON self-contained build (binaries V2, where the binaries are downloaded in parallel)
@@ -674,13 +675,13 @@ jobs:
         New-Item -Path '$(Build.SourcesDirectory)/src/dsc/bin/${{ parameters.BuildConfiguration }}/net6.0/linux-x64/publish/kubectl/linux' -ItemType Directory
 
         curl https://dl.k8s.io/release/v1.21.2/bin/linux/amd64/kubectl  -OutFile $(Build.SourcesDirectory)/src/dsc/bin/${{ parameters.BuildConfiguration }}/net6.0/linux-x64/publish/kubectl/linux/kubectl
-  - task: VSBuild@1
-    displayName: Sign Files
-    enabled: True
-    inputs:
-      solution: src/client.signproj
-      msbuildArgs: /t:SignFiles /p:SignType=real
-      configuration: '${{ parameters.BuildConfiguration }} '
+  #- task: VSBuild@1
+  #  displayName: Sign Files
+  #  enabled: True
+  #  inputs:
+  #    solution: src/client.signproj
+  #    msbuildArgs: /t:SignFiles /p:SignType=real
+  #    configuration: '${{ parameters.BuildConfiguration }} '
   - task: CopyFiles@2
     displayName: Collect files for .zip (Windows)
     inputs:
@@ -724,6 +725,7 @@ jobs:
     displayName: Validate Signatures
     inputs:
       Path: '$(Agent.TempDirectory)/zip/win'
+      continueOnError: false
   - task: CopyFiles@2
     displayName: Collect files for .zip (OSX)
     inputs:
@@ -771,6 +773,7 @@ jobs:
     displayName: Validate Signatures OSX
     inputs:
       Path: '$(Agent.TempDirectory)/zip/osx'
+      continueOnError: false
   - task: CopyFiles@2
     displayName: Collect files for .zip (Linux)
     inputs:
@@ -818,6 +821,7 @@ jobs:
     displayName: Validate Signatures linux
     inputs:
       Path: '$(Agent.TempDirectory)/zip/linux'
+      continueOnError: false
   - task: ArchiveFiles@2
     displayName: Create .zip file (Windows)
     inputs:
@@ -907,18 +911,18 @@ jobs:
       PathtoPublish: $(Build.ArtifactStagingDirectory)/zip
       ArtifactName: zipv2
 
-  - task: SdtReport@2
-    inputs:
-      GdnExportAllTools: true
-      GdnExportHtmlFile: true
-  - task: PublishSecurityAnalysisLogs@3
-    inputs:
-      ArtifactName: 'CodeAnalysisLogs'
-      ArtifactType: 'Container'
-      AllTools: true
-      ToolLogsNotFoundAction: 'Standard'
-  - task: PostAnalysis@2
-    inputs:
-      GdnBreakAllTools: true
-      GdnBreakFast: true
+  #- task: SdtReport@2
+  #  inputs:
+  #    GdnExportAllTools: true
+  #    GdnExportHtmlFile: true
+  #- task: PublishSecurityAnalysisLogs@3
+  #  inputs:
+  #    ArtifactName: 'CodeAnalysisLogs'
+  #    ArtifactType: 'Container'
+  #    AllTools: true
+  #    ToolLogsNotFoundAction: 'Standard'
+  #- task: PostAnalysis@2
+  #  inputs:
+  #    GdnBreakAllTools: true
+  #    GdnBreakFast: true
 ...

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -255,14 +255,14 @@ jobs:
         New-Item -Path './src/dsc/bin/${{ parameters.BuildConfiguration }}/net6.0/linux-x64/publish/kubectl/linux' -ItemType Directory
 
         curl https://dl.k8s.io/release/v1.21.2/bin/linux/amd64/kubectl  -OutFile ./src/dsc/bin/${{ parameters.BuildConfiguration }}/net6.0/linux-x64/publish/kubectl/linux/kubectl
-  - task: VSBuild@1
-    name: ''
-    displayName: Sign Files
-    enabled: True
-    inputs:
-      solution: src/client.signproj
-      msbuildArgs: /t:SignFiles /p:SignType=real
-      configuration: '${{ parameters.BuildConfiguration }} '
+  #- task: VSBuild@1
+  #  name: ''
+  #  displayName: Sign Files
+  #  enabled: True
+  #  inputs:
+  #    solution: src/client.signproj
+  #    msbuildArgs: /t:SignFiles /p:SignType=real
+  #    configuration: '${{ parameters.BuildConfiguration }} '
   - task: CopyFiles@2
     displayName: Collect files for .zip (Windows)
     enabled: True
@@ -675,13 +675,13 @@ jobs:
         New-Item -Path '$(Build.SourcesDirectory)/src/dsc/bin/${{ parameters.BuildConfiguration }}/net6.0/linux-x64/publish/kubectl/linux' -ItemType Directory
 
         curl https://dl.k8s.io/release/v1.21.2/bin/linux/amd64/kubectl  -OutFile $(Build.SourcesDirectory)/src/dsc/bin/${{ parameters.BuildConfiguration }}/net6.0/linux-x64/publish/kubectl/linux/kubectl
-  - task: VSBuild@1
-    displayName: Sign Files
-    enabled: True
-    inputs:
-      solution: src/client.signproj
-      msbuildArgs: /t:SignFiles /p:SignType=real
-      configuration: '${{ parameters.BuildConfiguration }} '
+  #- task: VSBuild@1
+    #displayName: Sign Files
+    #enabled: True
+    #inputs:
+    #  solution: src/client.signproj
+    #  msbuildArgs: /t:SignFiles /p:SignType=real
+    #  configuration: '${{ parameters.BuildConfiguration }} '
   - task: CopyFiles@2
     displayName: Collect files for .zip (Windows)
     inputs:
@@ -921,6 +921,8 @@ jobs:
       ToolLogsNotFoundAction: 'Standard'
   - task: PostAnalysis@2
     inputs:
-      GdnBreakAllTools: true
+      GdnBreakAllTools: false
+      GdnBreakGdnToolCodesignValidation: true
+      GdnBreakGdnToolCodesignValidationSeverity: Error
       GdnBreakFast: true
 ...


### PR DESCRIPTION
Currently signing verification happens on release nuget package pipeline. This change aim to add this check sooner on the release process.