### PR TITLE
Use endpoint dns if hostname not specified for the address

### DIFF
--- a/src/library.tests/WorkloadInformationProviderTests.cs
+++ b/src/library.tests/WorkloadInformationProviderTests.cs
@@ -30,19 +30,29 @@ namespace Microsoft.BridgeToKubernetes.Library.Tests
         }
 
         [Theory]
-        [InlineData(1, 100)]
-        [InlineData(5, 20)]
-        [InlineData(10, 3)]
-        [InlineData(2, 3)]
-        public async void GetReachableServicesAsync_HeadlessService(int numServices, int numAddresses)
+        [InlineData(1, 100, true)]
+        [InlineData(5, 20, false)]
+        [InlineData(10, 3, true)]
+        [InlineData(2, 3, false)]
+        public async void GetReachableServicesAsync_HeadlessService(int numServices, int numAddresses, bool isInWorkloadNamespace)
         {
-            ConfigureHeadlessService(numServices: numServices, namingFunction: (i) => $"myapp-{i}", numAddresses: numAddresses, addressHostNamingFunction: (i) => $"Host-{i}");
-            var result = await _workloadInformationProvider.GetReachableEndpointsAsync(namespaceName: "", localProcessConfig: null, includeSameNamespaceServices: true, cancellationToken: default(CancellationToken));
+            var expected = ConfigureHeadlessService(numServices: numServices, namingFunction: (i) => $"myapp-{i}", numAddresses: numAddresses, addressHostNamingFunction: (i) => $"Host-{i}", isInWorkloadNamespace);
+            var result = await _workloadInformationProvider.GetReachableEndpointsAsync(namespaceName: isInWorkloadNamespace ? "testNamespace" : "", localProcessConfig: null, includeSameNamespaceServices: true, cancellationToken: default(CancellationToken));
             // Doing numServices-1 when calculating because we are adding empty subset for one service and that will be skipped
-            Assert.Equal(numAddresses == 0 ? numServices : (numServices-1) * (numAddresses), result.Count());
+            Assert.Equal((numServices-1) * (numAddresses), result.Count());
             foreach (var endpoint in result) {
                 if (endpoint.Ports.Any()) {
                     Assert.Equal(endpoint.Ports.ElementAt(0).LocalPort, -1);
+                    bool found = false;
+                    foreach (var dns in expected) {
+                        if (string.Equals(endpoint.DnsName, dns))
+                        {
+                            found = true;
+                            expected.Remove(dns);
+                            break;
+                        }
+                    }
+                    Assert.True(found);
                 }
             }  
         }
@@ -281,8 +291,9 @@ namespace Microsoft.BridgeToKubernetes.Library.Tests
             A.CallTo(() => _autoFake.Resolve<IKubernetesClient>().ListServicesInNamespaceAsync(default, default, default)).WithAnyArguments().Returns(new V1ServiceList(serviceList));
         }
 
-        private void ConfigureHeadlessService(int numServices, Func<int, string> namingFunction, int numAddresses, Func<int, string> addressHostNamingFunction)
+        private List<string> ConfigureHeadlessService(int numServices, Func<int, string> namingFunction, int numAddresses, Func<int, string> addressHostNamingFunction, bool isInWorkloadNamespace)
         {
+            var result = new List<string>();
             var serviceList = new List<V1Service>();
             // introducing this variable so we can add an endpoint with empty subset to have crash coverage
             bool addSubset = false;
@@ -299,7 +310,8 @@ namespace Microsoft.BridgeToKubernetes.Library.Tests
                     },
                     Metadata = new V1ObjectMeta()
                     {
-                        Name = namingFunction(i)
+                        Name = namingFunction(i),
+                        NamespaceProperty = "testNamespace"
                     }
                 });
                 var subsets = new List<V1EndpointSubset>()
@@ -319,18 +331,32 @@ namespace Microsoft.BridgeToKubernetes.Library.Tests
                     Subsets = subsets,
                     Metadata = new V1ObjectMeta()
                     {
-                        Name = $"{namingFunction(i)}"
+                        Name = $"{namingFunction(i)}",
+                        NamespaceProperty = "testNamespace"
                     }
                 };
                 if (addSubset)
                 {
                     for (int j = 0; j < numAddresses; j++)
                     {
+                        // Allow empty hostname for better coverage
+                        string hostname = j%2 == 0 ? addressHostNamingFunction(j) : "";
                         endPoint.Subsets[0].Addresses.Add(new V1EndpointAddress
                         {
-                            // Allow empty hostname for better coverage
-                            Hostname = j%2 == 0 ? addressHostNamingFunction(j) : ""
+                            Hostname = hostname
                         });
+                        if (!string.IsNullOrEmpty(hostname))
+                        {
+                            result.Add(isInWorkloadNamespace ?
+                                    $"{hostname}.{namingFunction(i)}" :
+                                    $"{hostname}.{namingFunction(i)}.testNamespace");
+                        }
+                        else
+                        {
+                            result.Add(isInWorkloadNamespace ? 
+                                    namingFunction(i) : 
+                                    $"{namingFunction(i)}.testNamespace");
+                        }
                     }
                 }
                 else
@@ -341,6 +367,7 @@ namespace Microsoft.BridgeToKubernetes.Library.Tests
                 A.CallTo(() => _autoFake.Resolve<IKubernetesClient>().GetEndpointInNamespaceAsync(namingFunction(i), A<string>._, A<CancellationToken>._)).Returns(endPoint);
             }
             A.CallTo(() => _autoFake.Resolve<IKubernetesClient>().ListServicesInNamespaceAsync(default, default, default)).WithAnyArguments().Returns(new V1ServiceList(serviceList));
+            return result;
         }
     }
 }

--- a/src/library.tests/WorkloadInformationProviderTests.cs
+++ b/src/library.tests/WorkloadInformationProviderTests.cs
@@ -36,19 +36,19 @@ namespace Microsoft.BridgeToKubernetes.Library.Tests
         [InlineData(2, 3, false)]
         public async void GetReachableServicesAsync_HeadlessService(int numServices, int numAddresses, bool isInWorkloadNamespace)
         {
-            var expected = ConfigureHeadlessService(numServices: numServices, namingFunction: (i) => $"myapp-{i}", numAddresses: numAddresses, addressHostNamingFunction: (i) => $"Host-{i}", isInWorkloadNamespace);
-            var result = await _workloadInformationProvider.GetReachableEndpointsAsync(namespaceName: isInWorkloadNamespace ? "testNamespace" : "", localProcessConfig: null, includeSameNamespaceServices: true, cancellationToken: default(CancellationToken));
+            List<string> expectedDnsList = ConfigureHeadlessService(numServices: numServices, namingFunction: (i) => $"myapp-{i}", numAddresses: numAddresses, addressHostNamingFunction: (i) => $"Host-{i}", isInWorkloadNamespace);
+            var resultRechableEndpoints = await _workloadInformationProvider.GetReachableEndpointsAsync(namespaceName: isInWorkloadNamespace ? "testNamespace" : "", localProcessConfig: null, includeSameNamespaceServices: true, cancellationToken: default(CancellationToken));
             // Doing numServices-1 when calculating because we are adding empty subset for one service and that will be skipped
-            Assert.Equal((numServices-1) * (numAddresses), result.Count());
-            foreach (var endpoint in result) {
+            Assert.Equal((numServices-1) * (numAddresses), resultRechableEndpoints.Count());
+            foreach (var endpoint in resultRechableEndpoints) {
                 if (endpoint.Ports.Any()) {
                     Assert.Equal(endpoint.Ports.ElementAt(0).LocalPort, -1);
                     bool found = false;
-                    foreach (var dns in expected) {
+                    foreach (var dns in expectedDnsList) {
                         if (string.Equals(endpoint.DnsName, dns))
                         {
                             found = true;
-                            expected.Remove(dns);
+                            expectedDnsList.Remove(dns);
                             break;
                         }
                     }


### PR DESCRIPTION
This Pr address incorrect assumption done on [this PR](https://github.com/Azure/Bridge-To-Kubernetes/pull/78/files#diff-c415242ad7d5ebbf107822a6ba3ee5f15ccbbc0220f5948047db4f78bbe1add5). If address did not have hostname it was being skipped, but kubernetes still adds dns for it, it uses the endpoint dns if hostname not specified.

UTs have been updated accordingly.  Fixed also verified against set up that reproduced the issue.

Address #167 and #155. 