### PR TITLE
Updating database api project to dotnet 6

### DIFF
--- a/samples/todo-app/database-api/databaseApi.csproj
+++ b/samples/todo-app/database-api/databaseApi.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
     <DockerfileContext>.</DockerfileContext>
   </PropertyGroup>


### PR DESCRIPTION
This PR is to fix the deployment issue for database api in samples/todo/database-api due to dotnet version mismatch between csproj and docker file. 

![image](https://user-images.githubusercontent.com/105889062/224138143-f6d8f0c9-c928-48a3-88d0-fcf7c708548c.png)
