### PR TITLE
New feature: Disable Lifecycle Hooks in remote agent

### DIFF
--- a/src/library/Connect/Environment/EnableFeature.cs
+++ b/src/library/Connect/Environment/EnableFeature.cs
@@ -8,6 +8,7 @@ namespace Microsoft.BridgeToKubernetes.Library.Connect.Environment
     internal enum EnableFeature
     {
         ManagedIdentity,
-        Probes
+        Probes,
+        LifecycleHooks
     }
 }

--- a/src/library/Connect/Environment/ILocalProcessConfig.cs
+++ b/src/library/Connect/Environment/ILocalProcessConfig.cs
@@ -55,6 +55,11 @@ namespace Microsoft.BridgeToKubernetes.Library.Connect.Environment
         bool IsProbesEnabled { get; }
 
         /// <summary>
+        /// Is Container Lifecycle Hooks one of the enabled features
+        /// </summary>
+        bool IsLifecycleHooksEnabled { get; }
+
+        /// <summary>
         /// Returns a collection with the environment variables generated from the local env file
         /// </summary>
         /// <returns></returns>

--- a/src/library/Connect/Environment/LocalProcessConfig.cs
+++ b/src/library/Connect/Environment/LocalProcessConfig.cs
@@ -148,6 +148,11 @@ namespace Microsoft.BridgeToKubernetes.Library.Connect.Environment
                         {
                             this.IsProbesEnabled = true;
                         }
+
+                        if (StringComparer.OrdinalIgnoreCase.Equals(feature, EnableFeature.LifecycleHooks.ToString()))
+                        {
+                            this.IsLifecycleHooksEnabled = true;
+                        }
                     }
                 }
 
@@ -245,6 +250,11 @@ namespace Microsoft.BridgeToKubernetes.Library.Connect.Environment
         /// <see cref="ILocalProcessConfig.IsProbesEnabled"/>
         /// </summary>
         public bool IsProbesEnabled { get; } = false;
+
+        /// <summary>
+        /// <see cref="ILocalProcessConfig.IsLifecycleHooksEnabled"/>
+        /// </summary>
+        public bool IsLifecycleHooksEnabled { get; } = false;
 
         /// <summary>
         /// <see cref="ILocalProcessConfig.EvaluateEnvVars"/>

--- a/src/library/Connect/KubernetesRemoteEnvironmentManager.cs
+++ b/src/library/Connect/KubernetesRemoteEnvironmentManager.cs
@@ -487,6 +487,12 @@ namespace Microsoft.BridgeToKubernetes.Library.Connect
                         c.ReadinessProbe = null;
                         c.StartupProbe = null;
                     }
+
+                    // If lifecycle hooks option is not enabled or not set, remove any lifecycle hooks in the new pod.
+                    if (localProcessConfig?.IsLifecycleHooksEnabled != true)
+                    {
+                        c.Lifecycle = null;
+                    }
                 }
                 else
                 {
@@ -741,7 +747,7 @@ namespace Microsoft.BridgeToKubernetes.Library.Connect
                     catch (Exception ex)
                     {
                         var serializedPatch = StringManipulation.RemovePrivateKeyIfNeeded(patch.Serialize());
-                            
+
                         _log.Error($"Patch deployment {namespaceName}/{remoteContainerConnectionDetails.DeploymentName} failed. Patch is {serializedPatch}, {ex.Message}");
                         throw new UserVisibleException(_operationContext, ex, Resources.PatchResourceFailedFormat, KubernetesResourceType.Deployment.ToString(), namespaceName, deploymentName, serializedPatch, ex.Message);
                     }
@@ -1132,6 +1138,16 @@ namespace Microsoft.BridgeToKubernetes.Library.Connect
                 }
             }
 
+            // If lifecycle hooks option is not enabled or not set, remove any lifecycle hooks in the new pod.
+            if (localProcessConfig?.IsLifecycleHooksEnabled != true)
+            {
+                if (deployment.Spec.Template.Spec.Containers[containerIndex].Lifecycle != null)
+                {
+                    patch.Remove(d => d.Spec.Template.Spec.Containers[containerIndex].Lifecycle);
+                    reversePatch.Add(d => d.Spec.Template.Spec.Containers[containerIndex].Lifecycle, deployment.Spec.Template.Spec.Containers[containerIndex].Lifecycle);
+                }
+            }
+
             _log.Info($"Deployment patch created: {dirty}");
             return dirty ? (patch, reversePatch) : (null, null);
         }
@@ -1227,6 +1243,16 @@ namespace Microsoft.BridgeToKubernetes.Library.Connect
                 {
                     patch.Remove(d => d.Spec.Template.Spec.Containers[containerIndex].StartupProbe);
                     reversePatch.Add(d => d.Spec.Template.Spec.Containers[containerIndex].StartupProbe, statefulSet.Spec.Template.Spec.Containers[containerIndex].StartupProbe);
+                }
+            }
+
+            // If lifecycle hooks option is not enabled or not set, remove any lifecycle hooks in the new pod.
+            if (localProcessConfig?.IsLifecycleHooksEnabled != true)
+            {
+                if (statefulSet.Spec.Template.Spec.Containers[containerIndex].Lifecycle != null)
+                {
+                    patch.Remove(d => d.Spec.Template.Spec.Containers[containerIndex].Lifecycle);
+                    reversePatch.Add(d => d.Spec.Template.Spec.Containers[containerIndex].Lifecycle, statefulSet.Spec.Template.Spec.Containers[containerIndex].Lifecycle);
                 }
             }
 


### PR DESCRIPTION
This PR disables lifecycle hooks from beeing cloned to the remote agent pod when the remote agent is deployed.
Existing lifecycle hooks are restored when EndpointManager disconnects.

You can enable cloning of lifecycle hooks by adding the following line to the KubernetesLocalProcessConfig.yaml file.

```
enableFeatures:
  - LifecycleHooks  

```

Fixes #87 