### PR TITLE
update change log for release 04.25

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ If you are using one of the IDE extensions for Bridge to Kubernetes, check the r
 - [Visual Studio 2019 extension release notes](https://marketplace.visualstudio.com/items?itemName=ms-azuretools.mindaro#whats-new)
 - [Visual Studio 2022 extension release notes](https://marketplace.visualstudio.com/items?itemName=ms-azuretools.mindaro2022#whats-new)
 
+## [1.0.20230418.1]
+- [Enable auto review by chatgpt](https://github.com/Azure/Bridge-To-Kubernetes/pull/232)
+- [Update base images to microsoft mariner images](https://github.com/Azure/Bridge-To-Kubernetes/pull/175)
+- [Add new editor config files](https://github.com/Azure/Bridge-To-Kubernetes/pull/230)
+- [Added SupportedOSPlatformGuard and new improved operating system identification](https://github.com/Azure/Bridge-To-Kubernetes/pull/213)
+- [Remove root permissions for creating symlink in user's local bin folder](https://github.com/Azure/Bridge-To-Kubernetes/pull/216)
+- [Modified method to have one set of env variables and added UTs](https://github.com/Azure/Bridge-To-Kubernetes/pull/178)
+- [Json patch issue fix for stateful sets](https://github.com/Azure/Bridge-To-Kubernetes/pull/237)
+- [timeout override from getContainerEnv](https://github.com/Azure/Bridge-To-Kubernetes/pull/231)
+
 ## [1.0.20230327.2]
 - Address [Remove BouncyCastle Nuget package since .NET 6 can handle this internally](https://github.com/Azure/Bridge-To-Kubernetes/pull/183)
 - Address [Remove minimatch and replace it with internal .NET package](https://github.com/Azure/Bridge-To-Kubernetes/pull/184)


### PR DESCRIPTION
This PR is to update changelog to prepare for 04.25 release and below are changes that are rolled out in this release. Thank you. 

- [Enable auto review by chatgpt](https://github.com/Azure/Bridge-To-Kubernetes/pull/232)
- [Update base images to microsoft mariner images](https://github.com/Azure/Bridge-To-Kubernetes/pull/175)
- [Add new editor config files](https://github.com/Azure/Bridge-To-Kubernetes/pull/230)
- [Added SupportedOSPlatformGuard and new improved operating system identification](https://github.com/Azure/Bridge-To-Kubernetes/pull/213)
- [Remove root permissions for creating symlink in user's local bin folder](https://github.com/Azure/Bridge-To-Kubernetes/pull/216)
- [Modified method to have one set of env variables and added UTs](https://github.com/Azure/Bridge-To-Kubernetes/pull/178)
- [Json patch issue fix for stateful sets](https://github.com/Azure/Bridge-To-Kubernetes/pull/237)
- [timeout override from getContainerEnv](https://github.com/Azure/Bridge-To-Kubernetes/pull/231)