### PR TITLE
Fixed swaped arguments

### DIFF
--- a/src/common.tests/FixedSizeStringBuilderTests.cs
+++ b/src/common.tests/FixedSizeStringBuilderTests.cs
@@ -31,7 +31,7 @@ namespace Microsoft.BridgeToKubernetes.Common.Tests
             sb.AppendLine("12345");
             sb.Append("678910");
 
-            Assert.Equal(sb.ToString(), "...678910");
+            Assert.Equal("...678910", sb.ToString());
             Assert.True(sb.MaxLengthReached);
         }
 
@@ -42,7 +42,7 @@ namespace Microsoft.BridgeToKubernetes.Common.Tests
 
             sb.Append("12345678910");
 
-            Assert.Equal(sb.ToString(), "...2345678910");
+            Assert.Equal("...2345678910", sb.ToString());
             Assert.True(sb.MaxLengthReached);
         }
 

--- a/src/library.tests/PortMappingManagerTest.cs
+++ b/src/library.tests/PortMappingManagerTest.cs
@@ -51,8 +51,8 @@ namespace Microsoft.BridgeToKubernetes.Library.Tests
             var assignedPorts = new HashSet<int>();
             foreach (var endpoint in endpoints) {
                 foreach (var port in endpoint.Ports) {
-                    Assert.NotEqual(port.LocalPort, -1);
-                    Assert.False(assignedPorts.Contains(port.LocalPort));
+                    Assert.NotEqual(-1, port.LocalPort);
+                    Assert.DoesNotContain(port.LocalPort, assignedPorts);
                     assignedPorts.Add(port.LocalPort);
                 }
             }   

--- a/src/library.tests/RemoteContainerConnectionDetailsResolverTests.cs
+++ b/src/library.tests/RemoteContainerConnectionDetailsResolverTests.cs
@@ -48,7 +48,7 @@ namespace Microsoft.BridgeToKubernetes.Library.Tests
                 // We only care about this exception for this UT. ResolveConnectionDetails is large function and ot get to pass cleanly would require a lot longer set up,
                 // which is not needed for this UT
                 if (e.Message.StartsWith("Restoration pod is still present for the specified service")) {
-                    Assert.Equal(phase, "Running");
+                    Assert.Equal("Running", phase);
                     Assert.True(hasRestore);
                 }
             }


### PR DESCRIPTION
This PR fixes some tests that had swaped the actual argument with the expected argument.
It also optimizes a test by using Assert.DoesNotContains instead of multiple checks.

This change removes 4 warnings.

Fixed #254 