### PR TITLE
update issue template with b2k logs location 

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -27,7 +27,7 @@ A clear and concise description of what you expected to happen.
 If applicable, add screenshots to help explain your problem.
 
 **Logs:**
- - Please attach logs for Bridge to Kubernetes to triage issues faster, here are the log locations ( Window C:\Users\Username\AppData\Local\Temp\Bridge To Kubernetes, Linux/Mac - $HOME/tmp/Bridge To Kubernetes or /tmp/Bridge To Kubernetes). Please attach logs relevant to your issue or bug. 
+ - Please attach logs for Bridge to Kubernetes to triage issues faster, here are the log locations ( Window like C:\Users\Username\AppData\Local\Temp\Bridge To Kubernetes, Linux/Mac like $HOME/tmp/Bridge To Kubernetes or /tmp/Bridge To Kubernetes). Please attach logs relevant to your issue or bug. 
 
 **Desktop (please complete the following information):**
  - OS: [e.g. iOS]

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,7 +2,7 @@
 name: Bug report
 about: Create a report to help us improve
 title: ''
-labels: ''
+labels: bug
 assignees: ''
 
 ---
@@ -25,6 +25,9 @@ A clear and concise description of what you expected to happen.
 
 **Screenshots**
 If applicable, add screenshots to help explain your problem.
+
+**Logs:**
+ - Please attach logs for Bridge to Kubernetes to triage issues faster, here are the log locations ( Window C:\Users\Username\AppData\Local\Temp\Bridge To Kubernetes, Linux/Mac - $HOME/tmp/Bridge To Kubernetes or /tmp/Bridge To Kubernetes). Please attach logs relevant to your issue or bug. 
 
 **Desktop (please complete the following information):**
  - OS: [e.g. iOS]

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -2,7 +2,7 @@
 name: Feature request
 about: Suggest an idea for this project
 title: ''
-labels: ''
+labels: enhancement
 assignees: ''
 
 ---


### PR DESCRIPTION
This PR is to update bug/issue/feature request templates with labels and include logs location so that users can include the logs from their dev machines for faster triaging. 