### PR TITLE
Added jaeger-agent as known sidecar

### DIFF
--- a/src/library/Extensions/V1ContainerExtensions.cs
+++ b/src/library/Extensions/V1ContainerExtensions.cs
@@ -13,7 +13,8 @@ namespace k8s.Models
         {
             return StringComparer.OrdinalIgnoreCase.Equals(container.Name, "devspaces-proxy")
                     || StringComparer.OrdinalIgnoreCase.Equals(container.Name, "istio-proxy")
-                    || StringComparer.OrdinalIgnoreCase.Equals(container.Name, "daprd");
+                    || StringComparer.OrdinalIgnoreCase.Equals(container.Name, "daprd")
+                    || StringComparer.OrdinalIgnoreCase.Equals(container.Name, "jaeger-agent");
         }
     }
 }


### PR DESCRIPTION
See also https://github.com/Azure/Bridge-To-Kubernetes/issues/292

This PR allows Jaeger side car support by bridge.