### PR TITLE
Install script - update to dotnet 7.0

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -110,7 +110,7 @@ check_dotnet_runtime_present() {
     fi
     #if dotnet exists, check the version required for b2k and install it.
     dotnetruntimes=$(dotnet --list-runtimes)
-    if [[ -z "${dotnetruntimes}" || ! "${dotnetruntimes}" =~ '6.0'* ]]; then
+    if [[ -z "${dotnetruntimes}" || ! "${dotnetruntimes}" =~ '7.0'* ]]; then
         install_tool dotnet
     else 
         log INFO "dotnet version is $(dotnet --version)"
@@ -132,12 +132,12 @@ install_tool() {
                     install_dotnet_x64_for_arm
                 else 
                     $PACKAGER tap isen-ng/dotnet-sdk-versions
-                    install_with_sudo dotnet-sdk6-0-400 --cask
+                    install_with_sudo dotnet-sdk7-0-300 --cask
                 fi 
             elif [[ $OSTYPE == "linux"* ]]; then
-                install_with_sudo dotnet-sdk-6.0
+                install_with_sudo dotnet-sdk-7.0
             else 
-                install_with_sudo dotnet-6.0-sdk -y
+                install_with_sudo dotnet-7.0-sdk -y
             fi
             ;;
         jq)
@@ -152,7 +152,7 @@ install_tool() {
 
 install_dotnet_x64_for_arm() {
     log INFO "downloading and installing dotnet x64 binaries in arm machines"
-    curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin --version 6.0.406 --arch x64
+    curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin --version 7.0.306 --arch x64
     if [[ ! -d /usr/local/share/dotnet ]] || [[ ! -d /usr/local/share/dotnet/x64 ]]; then
         sudo mkdir -p /usr/local/share/dotnet/x64
     fi

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -153,7 +153,7 @@ install_tool() {
 
 install_pre_requirements_kubectl() {
     if [[ $OSTYPE == "linux"* ]]; then
-        #add google packages to install kubectl
+        #add google packages to install kubectl or else apt install kubectl will give error kubectl not found.
         sudo $PACKAGER update
         sudo $PACKAGER install -y ca-certificates curl
         sudo $PACKAGER install -y apt-transport-https

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -123,6 +123,7 @@ install_tool() {
     case $1 in 
 
         kubectl)
+            install_pre_requirements_kubectl
             install_with_sudo kubectl
             ;;
         dotnet)
@@ -148,6 +149,18 @@ install_tool() {
             exit 1
             ;;
     esac
+}
+
+install_pre_requirements_kubectl() {
+    if [[ $OSTYPE == "linux"* ]]; then
+        #add google packages to install kubectl
+        sudo $PACKAGER update
+        sudo $PACKAGER install -y ca-certificates curl
+        sudo $PACKAGER install -y apt-transport-https
+        curl -fsSL https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo gpg --dearmor -o /etc/apt/keyrings/kubernetes-archive-keyring.gpg
+        echo "deb [signed-by=/etc/apt/keyrings/kubernetes-archive-keyring.gpg] https://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee /etc/apt/sources.list.d/kubernetes.list
+        sudo $PACKAGER update
+    fi
 }
 
 install_dotnet_x64_for_arm() {

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -110,7 +110,7 @@ check_dotnet_runtime_present() {
     fi
     #if dotnet exists, check the version required for b2k and install it.
     dotnetruntimes=$(dotnet --list-runtimes)
-    if [[ -z "${dotnetruntimes}" || ! "${dotnetruntimes}" =~ '7.0'* ]]; then
+    if [[ -z "${dotnetruntimes}" ]] || ! ([[ "${dotnetruntimes}" =~ '7.0'* ]] && [[ "${dotnetruntimes}" =~ 'AspNetCore'* ]]); then
         install_tool dotnet
     else 
         log INFO "dotnet version is $(dotnet --version)"


### PR DESCRIPTION
This PR is to update install script to download and use dotnet 7.0. Made a small improvement to install aspnetcore-runtime even if dotnet sdk and dotnetruntime exists because bridge requires aspnetcore-runtime.

```
curl -fsSL https://raw.githubusercontent.com/hsubramanianaks/Bridge-To-Kubernetes/install-script-dotnet7/scripts/install.sh | bash
```

**Testing screenshots:**

**Ubuntu 20.04:**

![image](https://github.com/Azure/Bridge-To-Kubernetes/assets/105889062/de5aed7d-5fc0-46b2-a2a1-77a164bbfdc0)

![image](https://github.com/Azure/Bridge-To-Kubernetes/assets/105889062/acee6f91-4b2e-441f-8d4c-51cd03ef524d)




**Windows - Gitbash**
![image](https://github.com/Azure/Bridge-To-Kubernetes/assets/105889062/d9fa4415-f7fd-4105-88d2-1c346137ea53)

![image](https://github.com/Azure/Bridge-To-Kubernetes/assets/105889062/7ccaf8e3-d14e-4d93-965e-4f0f876a215e)



**Macos - amd64**
![image](https://github.com/Azure/Bridge-To-Kubernetes/assets/105889062/159f5b58-9d5f-4e8a-8c2f-aa9b6c191795)


**Macos-arm64**

![image](https://github.com/Azure/Bridge-To-Kubernetes/assets/105889062/09911769-f4a4-46c8-8a82-0a2e52a3a92b)







