### PR TITLE
add live-test dispatch workflow for windows and mac

### DIFF
--- a/.github/workflows/live-test.yml
+++ b/.github/workflows/live-test.yml
@@ -8,8 +8,7 @@ jobs:
       PR_NUMBER: ${{ github.event.client_payload.slash_command.args.named.PR_NUMBER }}
     strategy:
       matrix:
-        # os: [ubuntu-latest, windows-latest, macos-latest]
-         os: [macos-latest]
+        os: [ubuntu-latest, windows-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     name: live test for b2k
     steps:
@@ -24,34 +23,28 @@ jobs:
       run: |
         echo "mac_cluster=b2k-livetest-mac-pr-$PR_NUMBER" >> $GITHUB_ENV
         echo "windows_cluster=b2k-livetest-windows-pr-$PR_NUMBER" >> $GITHUB_ENV
-    # todo: actually create an AKS
+    # create cluster for Windows
     - name: Create AKS for Windows
       if: ${{ matrix.os == 'windows-latest' }}
-      uses: Azure/powershell@v1
-      with:
-        inlineScript: |
-          az resource list -g ${{ secrets.AZURE_RESOURCE_GROUP }}
-        azPSVersion: '3.1.0'
+      run: |
+        az aks create -g ${{ secrets.AZURE_RESOURCE_GROUP }} -n ${{ env.windows_cluster }} --no-ssh-key
     - name: Set AKS Context for Windows
       if: ${{ matrix.os == 'windows-latest' }}
       uses: azure/aks-set-context@v3
       with:
-        # todo: set to the actually created AKS
         resource-group: ${{ secrets.AZURE_RESOURCE_GROUP }}
-        cluster-name: testworkflow-aks
-    - name: Create AKS Mac
+        cluster-name: ${{ env.windows_cluster }}
+    # create cluster for Mac
+    - name: Create AKS mac
       if: ${{ matrix.os == 'macos-latest' }}
-      uses: Azure/powershell@v1
-      with:
-        inlineScript: |
-          az aks create -g ${{ secrets.AZURE_RESOURCE_GROUP }} -n $mac_cluster
-        azPSVersion: '3.1.0'
+      run: |
+        az aks create -g ${{ secrets.AZURE_RESOURCE_GROUP }} -n ${{ env.mac_cluster }} --no-ssh-key
     - name: Set AKS Context for MacOS
       if: ${{ matrix.os == 'macos-latest' }}
       uses: azure/aks-set-context@v3
       with:
         resource-group: ${{ secrets.AZURE_RESOURCE_GROUP }}
-        cluster-name: $mac_cluster
+        cluster-name: ${{ env.mac_cluster }}
     - name: Setup kubectl for macos-latest
       if: ${{ matrix.os == 'macos-latest' }}
       uses: azure/setup-kubectl@v3

--- a/.github/workflows/live-test.yml
+++ b/.github/workflows/live-test.yml
@@ -2,6 +2,8 @@ name: Live tests for B2K
 on:
   repository_dispatch:
     types: [ok-to-test-command]
+permissions:
+  id-token: write
 jobs:
   liveTest:
     env:
@@ -10,7 +12,7 @@ jobs:
       HEAD_BRANCH: ${{ github.event.client_payload.slash_command.args.named.HEAD_BRANCH }}
     strategy:
       matrix:
-        os: [macos-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     name: live test for b2k
     steps:
@@ -23,7 +25,9 @@ jobs:
       if: ${{ matrix.os != 'ubuntu-latest' }}
       uses: Azure/login@v1
       with:
-        creds: '{"clientId":"${{ secrets.AZURE_CLIENT_ID }}","clientSecret":"${{ secrets.AZURE_CLIENT_SECRET }}","subscriptionId":"${{ secrets.AZURE_SUBSCRIPTION_ID }}","tenantId":"${{ secrets.AZURE_TENANT_ID }}"}'
+        tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+        subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+        client-id: ${{ secrets.AZURE_CLIENT_ID }}
     - name: Prepare Cluster name Windows
       if: ${{ matrix.os == 'windows-latest' }}
       run: |

--- a/.github/workflows/live-test.yml
+++ b/.github/workflows/live-test.yml
@@ -6,13 +6,19 @@ jobs:
   liveTest:
     env:
       PR_NUMBER: ${{ github.event.client_payload.slash_command.args.named.PR_NUMBER }}
+      HEAD_REPO: ${{ github.event.client_payload.slash_command.args.named.HEAD_REPO }}
+      HEAD_BRANCH: ${{ github.event.client_payload.slash_command.args.named.HEAD_BRANCH }}
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [macos-latest]
     runs-on: ${{ matrix.os }}
     name: live test for b2k
     steps:
     - uses: actions/checkout@v2
+      # checkout PR head repo/branch
+      with:
+         repository: ${{ env.HEAD_REPO }}
+         ref: ${{ env.HEAD_BRANCH }}
     - name: Login Azure Context
       if: ${{ matrix.os != 'ubuntu-latest' }}
       uses: Azure/login@v1

--- a/.github/workflows/live-test.yml
+++ b/.github/workflows/live-test.yml
@@ -1,17 +1,15 @@
 name: Live tests for B2K
 on:
-  # push:
-  #   branches: [ "main" ]
-  # pull_request:
-  #   branches: [ "main" ]
   repository_dispatch:
     types: [ok-to-test-command]
 jobs:
   liveTest:
+    env:
+      PR_NUMBER: ${{ github.event.client_payload.slash_command.args.named.PR_NUMBER }}
     strategy:
       matrix:
         # os: [ubuntu-latest, windows-latest, macos-latest]
-         os: [ubuntu-latest]
+         os: [macos-latest]
     runs-on: ${{ matrix.os }}
     name: live test for b2k
     steps:
@@ -21,6 +19,11 @@ jobs:
       uses: Azure/login@v1
       with:
         creds: '{"clientId":"${{ secrets.AZURE_CLIENT_ID }}","clientSecret":"${{ secrets.AZURE_CLIENT_SECRET }}","subscriptionId":"${{ secrets.AZURE_SUBSCRIPTION_ID }}","tenantId":"${{ secrets.AZURE_TENANT_ID }}"}'
+    - name: Prepare AKS Cluster name
+      if: ${{ matrix.os != 'ubuntu-latest' }}
+      run: |
+        echo "mac_cluster=b2k-livetest-mac-pr-$PR_NUMBER" >> $GITHUB_ENV
+        echo "windows_cluster=b2k-livetest-windows-pr-$PR_NUMBER" >> $GITHUB_ENV
     # todo: actually create an AKS
     - name: Create AKS for Windows
       if: ${{ matrix.os == 'windows-latest' }}
@@ -36,14 +39,19 @@ jobs:
         # todo: set to the actually created AKS
         resource-group: ${{ secrets.AZURE_RESOURCE_GROUP }}
         cluster-name: testworkflow-aks
-    # todo: step:Create AKS for MacOS
+    - name: Create AKS Mac
+      if: ${{ matrix.os == 'macos-latest' }}
+      uses: Azure/powershell@v1
+      with:
+        inlineScript: |
+          az aks create -g ${{ secrets.AZURE_RESOURCE_GROUP }} -n $mac_cluster
+        azPSVersion: '3.1.0'
     - name: Set AKS Context for MacOS
       if: ${{ matrix.os == 'macos-latest' }}
       uses: azure/aks-set-context@v3
       with:
-        # todo: set to the actually created AKS
         resource-group: ${{ secrets.AZURE_RESOURCE_GROUP }}
-        cluster-name: workflowtest-mac-aks
+        cluster-name: $mac_cluster
     - name: Setup kubectl for macos-latest
       if: ${{ matrix.os == 'macos-latest' }}
       uses: azure/setup-kubectl@v3

--- a/.github/workflows/live-test.yml
+++ b/.github/workflows/live-test.yml
@@ -1,24 +1,56 @@
 name: Live tests for B2K
 on:
-  push:
-    branches: [ "main" ]
-  pull_request:
-    branches: [ "main" ]
+  # push:
+  #   branches: [ "main" ]
+  # pull_request:
+  #   branches: [ "main" ]
+  repository_dispatch:
+    types: [ok-to-test-command]
 jobs:
   liveTest:
     strategy:
       matrix:
-        os: [ubuntu-latest]
+        # os: [ubuntu-latest, windows-latest, macos-latest]
+         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     name: live test for b2k
     steps:
     - uses: actions/checkout@v2
+    - name: Login Azure Context
+      if: ${{ matrix.os != 'ubuntu-latest' }}
+      uses: Azure/login@v1
+      with:
+        creds: '{"clientId":"${{ secrets.AZURE_CLIENT_ID }}","clientSecret":"${{ secrets.AZURE_CLIENT_SECRET }}","subscriptionId":"${{ secrets.AZURE_SUBSCRIPTION_ID }}","tenantId":"${{ secrets.AZURE_TENANT_ID }}"}'
+    # todo: actually create an AKS
+    - name: Create AKS for Windows
+      if: ${{ matrix.os == 'windows-latest' }}
+      uses: Azure/powershell@v1
+      with:
+        inlineScript: |
+          az resource list -g ${{ secrets.AZURE_RESOURCE_GROUP }}
+        azPSVersion: '3.1.0'
+    - name: Set AKS Context for Windows
+      if: ${{ matrix.os == 'windows-latest' }}
+      uses: azure/aks-set-context@v3
+      with:
+        # todo: set to the actually created AKS
+        resource-group: ${{ secrets.AZURE_RESOURCE_GROUP }}
+        cluster-name: testworkflow-aks
+    # todo: step:Create AKS for MacOS
+    - name: Set AKS Context for MacOS
+      if: ${{ matrix.os == 'macos-latest' }}
+      uses: azure/aks-set-context@v3
+      with:
+        # todo: set to the actually created AKS
+        resource-group: ${{ secrets.AZURE_RESOURCE_GROUP }}
+        cluster-name: workflowtest-mac-aks
     - name: Setup kubectl for macos-latest
       if: ${{ matrix.os == 'macos-latest' }}
       uses: azure/setup-kubectl@v3
       with:
-       version: latest
-    - name: Start minikube
+        version: latest
+    - name: Start minikube for ubuntu 
+      if: ${{ matrix.os == 'ubuntu-latest' }}
       uses: medyagh/setup-minikube@c8adc427cd854219da7bdea2f5fce5d23c89512a
       with:
        driver: docker
@@ -32,7 +64,7 @@ jobs:
         kubectl wait --for=condition=ready pod --all -n todo-app --timeout=300s
         kubectl get pods -n todo-app
     - name: Publish and test
-      timeout-minutes: 10
+      timeout-minutes: 30
       shell: bash
       run: |
        echo "RUNNER OS IS: $RUNNER_OS"

--- a/.github/workflows/live-test.yml
+++ b/.github/workflows/live-test.yml
@@ -7,9 +7,11 @@ permissions:
 jobs:
   liveTest:
     env:
-      PR_NUMBER: ${{ github.event.client_payload.slash_command.args.named.PR_NUMBER }}
-      HEAD_REPO: ${{ github.event.client_payload.slash_command.args.named.HEAD_REPO }}
-      HEAD_BRANCH: ${{ github.event.client_payload.slash_command.args.named.HEAD_BRANCH }}
+      PR_NUMBER: ${{ github.event.client_payload.pull_request.number }}
+    if:
+      github.event_name == 'repository_dispatch' &&
+      github.event.client_payload.slash_command.args.named.sha != '' &&
+      contains(github.event.client_payload.pull_request.head.sha, github.event.client_payload.slash_command.args.named.sha)
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
@@ -17,10 +19,8 @@ jobs:
     name: live test for b2k
     steps:
     - uses: actions/checkout@v2
-      # checkout PR head repo/branch
       with:
-         repository: ${{ env.HEAD_REPO }}
-         ref: ${{ env.HEAD_BRANCH }}
+        ref: refs/pull/${{ github.event.client_payload.pull_request.number }}/merge
     - name: Login Azure Context
       if: ${{ matrix.os != 'ubuntu-latest' }}
       uses: Azure/login@v1

--- a/.github/workflows/live-test.yml
+++ b/.github/workflows/live-test.yml
@@ -95,6 +95,6 @@ jobs:
       if: always()
       shell: bash
       run: |
-        if [ az aks list -g ConnectTesting --query "[?name=='${{ env.cluster_name }}'] | length(@)" > 0 ]; then
+        if [ $(az aks list -g ${{ secrets.AZURE_RESOURCE_GROUP }} --query "[?name=='${{ env.cluster_name }}'] | length(@)") > 0 ]; then
           az aks delete -n ${{ env.cluster_name }} -g ${{ secrets.AZURE_RESOURCE_GROUP }} -y --no-wait
         fi

--- a/.github/workflows/live-test.yml
+++ b/.github/workflows/live-test.yml
@@ -28,36 +28,27 @@ jobs:
         tenant-id: ${{ secrets.AZURE_TENANT_ID }}
         subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
         client-id: ${{ secrets.AZURE_CLIENT_ID }}
-    - name: Prepare Cluster name Windows
-      if: ${{ matrix.os == 'windows-latest' }}
+    - name: Prepare Cluster name Mac and Windows
+      if: ${{ matrix.os == 'macos-latest' ||  matrix.os == 'windows-latest' }}
+      shell: bash
       run: |
-        echo "windows_cluster=b2k-livetest-win-pr-$env:PR_NUMBER" >> $env:GITHUB_ENV
-    # create cluster for Windows
-    - name: Create AKS for Windows
-      if: ${{ matrix.os == 'windows-latest' }}
+        if [ "$RUNNER_OS" == "Windows" ]; then
+          echo "cluster_name=b2k-livetest-win-pr-$PR_NUMBER" >> $GITHUB_ENV
+        else
+          echo "cluster_name=b2k-livetest-mac-pr-$PR_NUMBER" >> $GITHUB_ENV
+        fi
+    - name: Create AKS Mac and Windows
+      if: ${{ matrix.os == 'macos-latest' ||  matrix.os == 'windows-latest' }}
+      shell: bash
       run: |
-        az aks create -g ${{ secrets.AZURE_RESOURCE_GROUP }} -n ${{ env.windows_cluster }} --no-ssh-key
-    - name: Set AKS Context for Windows
-      if: ${{ matrix.os == 'windows-latest' }}
+        az aks create -g ${{ secrets.AZURE_RESOURCE_GROUP }} -n ${{ env.cluster_name }} --no-ssh-key
+        echo "create_cluster=success" >> $GITHUB_ENV
+    - name: Set AKS Context Mac and Windows
+      if: ${{ matrix.os == 'macos-latest' ||  matrix.os == 'windows-latest' }}
       uses: azure/aks-set-context@v3
       with:
         resource-group: ${{ secrets.AZURE_RESOURCE_GROUP }}
-        cluster-name: ${{ env.windows_cluster }}
-    - name: Prepare Cluster name Mac
-      if: ${{ matrix.os == 'macos-latest' }}
-      run: |
-        echo "mac_cluster=b2k-livetest-mac-pr-$PR_NUMBER" >> $GITHUB_ENV
-    # create cluster for Mac
-    - name: Create AKS mac
-      if: ${{ matrix.os == 'macos-latest' }}
-      run: |
-        az aks create -g ${{ secrets.AZURE_RESOURCE_GROUP }} -n ${{ env.mac_cluster }} --no-ssh-key
-    - name: Set AKS Context for MacOS
-      if: ${{ matrix.os == 'macos-latest' }}
-      uses: azure/aks-set-context@v3
-      with:
-        resource-group: ${{ secrets.AZURE_RESOURCE_GROUP }}
-        cluster-name: ${{ env.mac_cluster }}
+        cluster-name: ${{ env.cluster_name }}
     - name: Setup kubectl for macos-latest
       if: ${{ matrix.os == 'macos-latest' }}
       uses: azure/setup-kubectl@v3
@@ -99,3 +90,11 @@ jobs:
           chmod +x scripts/verify.sh
         fi
         ./scripts/verify.sh
+
+    - name: cleanup AKS cluster
+      if: always()
+      shell: bash
+      run: |
+        if [ az aks list -g ConnectTesting --query "[?name=='${{ env.cluster_name }}'] | length(@)" > 0 ]; then
+          az aks delete -n ${{ env.cluster_name }} -g ${{ secrets.AZURE_RESOURCE_GROUP }} -y --no-wait
+        fi

--- a/.github/workflows/live-test.yml
+++ b/.github/workflows/live-test.yml
@@ -18,11 +18,10 @@ jobs:
       uses: Azure/login@v1
       with:
         creds: '{"clientId":"${{ secrets.AZURE_CLIENT_ID }}","clientSecret":"${{ secrets.AZURE_CLIENT_SECRET }}","subscriptionId":"${{ secrets.AZURE_SUBSCRIPTION_ID }}","tenantId":"${{ secrets.AZURE_TENANT_ID }}"}'
-    - name: Prepare AKS Cluster name
-      if: ${{ matrix.os != 'ubuntu-latest' }}
+    - name: Prepare Cluster name Windows
+      if: ${{ matrix.os == 'windows-latest' }}
       run: |
-        echo "mac_cluster=b2k-livetest-mac-pr-$PR_NUMBER" >> $GITHUB_ENV
-        echo "windows_cluster=b2k-livetest-windows-pr-$PR_NUMBER" >> $GITHUB_ENV
+        echo "windows_cluster=b2k-livetest-win-pr-$env:PR_NUMBER" >> $env:GITHUB_ENV
     # create cluster for Windows
     - name: Create AKS for Windows
       if: ${{ matrix.os == 'windows-latest' }}
@@ -34,6 +33,10 @@ jobs:
       with:
         resource-group: ${{ secrets.AZURE_RESOURCE_GROUP }}
         cluster-name: ${{ env.windows_cluster }}
+    - name: Prepare Cluster name Mac
+      if: ${{ matrix.os == 'macos-latest' }}
+      run: |
+        echo "mac_cluster=b2k-livetest-mac-pr-$PR_NUMBER" >> $GITHUB_ENV
     # create cluster for Mac
     - name: Create AKS mac
       if: ${{ matrix.os == 'macos-latest' }}

--- a/.github/workflows/ok-to-test.yml
+++ b/.github/workflows/ok-to-test.yml
@@ -1,0 +1,27 @@
+# File based on https://github.com/imjohnbo/ok-to-test/blob/master/.github/workflows/ok-to-test.yml
+name: Ok To Test
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  ok-to-test:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      issues: write
+      contents: write
+
+    # Only run for PRs, not issue comments
+    if: ${{ github.event.issue.pull_request }}
+    steps:
+      - name: slash command dispatch
+        uses: peter-evans/slash-command-dispatch@a28ee6cd74d5200f99e247ebc7b365c03ae0ef3c # v3.0.1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          reaction-token: ${{ secrets.GITHUB_TOKEN }}
+          issue-type: pull-request
+          commands: ok-to-test
+          permission: write
+          

--- a/.github/workflows/ok-to-test.yml
+++ b/.github/workflows/ok-to-test.yml
@@ -23,5 +23,7 @@ jobs:
           reaction-token: ${{ secrets.GITHUB_TOKEN }}
           issue-type: pull-request
           commands: ok-to-test
+          static-args: |
+            PR_NUMBER=${{ github.event.issue.number }}
           permission: write
           

--- a/.github/workflows/ok-to-test.yml
+++ b/.github/workflows/ok-to-test.yml
@@ -16,29 +16,6 @@ jobs:
     # Only run for PRs, not issue comments
     if: ${{ github.event.issue.pull_request }}
     steps:
-      - name: Resolve PR
-        id: resolve-pr
-        uses: actions/github-script@v3
-        with:
-          script: |
-              const request = {
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  pull_number: context.issue.number
-              }
-              core.info(`Getting PR #${request.pull_number} from ${request.owner}/${request.repo}`)
-              try {
-                  const result = await github.pulls.get(request)
-                  return result.data
-              } catch (err) {
-                  core.setFailed(`Request failed with error ${err}`)
-              }
-      - name: Print pr data
-        run: |
-            echo head repository is ${{ fromJSON(steps.resolve-pr.outputs.result).head.repo.full_name }}
-            echo head branch is ${{ fromJSON(steps.resolve-pr.outputs.result).head.ref }}
-            echo head sha is ${{ fromJSON(steps.resolve-pr.outputs.result).head.sha }}
-
       - name: slash command dispatch
         uses: peter-evans/slash-command-dispatch@a28ee6cd74d5200f99e247ebc7b365c03ae0ef3c # v3.0.1
         with:
@@ -46,10 +23,5 @@ jobs:
           reaction-token: ${{ secrets.GITHUB_TOKEN }}
           issue-type: pull-request
           commands: ok-to-test
-          static-args: |
-            PR_NUMBER=${{ github.event.issue.number }}
-            HEAD_REPO=${{ fromJSON(steps.resolve-pr.outputs.result).head.repo.full_name }}
-            HEAD_BRANCH=${{ fromJSON(steps.resolve-pr.outputs.result).head.ref }}
-            LAST_SHA=${{ fromJSON(steps.resolve-pr.outputs.result).head.sha }}
           permission: write
           

--- a/.github/workflows/ok-to-test.yml
+++ b/.github/workflows/ok-to-test.yml
@@ -16,6 +16,29 @@ jobs:
     # Only run for PRs, not issue comments
     if: ${{ github.event.issue.pull_request }}
     steps:
+      - name: Resolve PR
+        id: resolve-pr
+        uses: actions/github-script@v3
+        with:
+          script: |
+              const request = {
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  pull_number: context.issue.number
+              }
+              core.info(`Getting PR #${request.pull_number} from ${request.owner}/${request.repo}`)
+              try {
+                  const result = await github.pulls.get(request)
+                  return result.data
+              } catch (err) {
+                  core.setFailed(`Request failed with error ${err}`)
+              }
+      - name: Print pr data
+        run: |
+            echo head repository is ${{ fromJSON(steps.resolve-pr.outputs.result).head.repo.full_name }}
+            echo head branch is ${{ fromJSON(steps.resolve-pr.outputs.result).head.ref }}
+            echo head sha is ${{ fromJSON(steps.resolve-pr.outputs.result).head.sha }}
+
       - name: slash command dispatch
         uses: peter-evans/slash-command-dispatch@a28ee6cd74d5200f99e247ebc7b365c03ae0ef3c # v3.0.1
         with:
@@ -25,5 +48,8 @@ jobs:
           commands: ok-to-test
           static-args: |
             PR_NUMBER=${{ github.event.issue.number }}
+            HEAD_REPO=${{ fromJSON(steps.resolve-pr.outputs.result).head.repo.full_name }}
+            HEAD_BRANCH=${{ fromJSON(steps.resolve-pr.outputs.result).head.ref }}
+            LAST_SHA=${{ fromJSON(steps.resolve-pr.outputs.result).head.sha }}
           permission: write
           

--- a/scripts/verify.sh
+++ b/scripts/verify.sh
@@ -30,7 +30,7 @@ verify_if_multiple_pods_exists() {
     echo "Verifying if multiple pods exists"
     count=0
     MULTIPLE_POD_EXISTS=false
-    while [ "$count" -le 3 ]; do
+    while [ "$count" -le 10 ]; do
         STATS_API=$(kubectl get pods -n todo-app | grep "stats-api")
         echo "stats api pods: $STATS_API"
         echo "stats api length: ${#STATS_API}"


### PR DESCRIPTION
See https://github.com/Azure/Bridge-To-Kubernetes/issues/140
This PR: 
Adds live test for windows and mac, workflow will create an AKS cluster to run the test.
No changes to test for linux
Now the tests for all 3 platforms will be triggered by slash command and `sha` input like `/ok-to-test sha=1234567` in PR comment

A latest run in my fork: https://github.com/cxznmhdcxz/Bridge-To-Kubernetes/actions/runs/5798264426

