### PR TITLE
Filter pods which are not replicatset or statefulset

### DIFF
--- a/src/library/Extensions/V1PodExtensions.cs
+++ b/src/library/Extensions/V1PodExtensions.cs
@@ -4,6 +4,7 @@
 // --------------------------------------------------------------------------------------------
 
 using System;
+using System.Linq;
 using Microsoft.BridgeToKubernetes.Common;
 using Microsoft.BridgeToKubernetes.Common.Exceptions;
 using Microsoft.BridgeToKubernetes.Common.Kubernetes;
@@ -25,5 +26,8 @@ namespace k8s.Models
                 throw new UserVisibleException(context, Resources.WindowsContainersNotSupportedFormat, Product.Name);
             }
         }
+
+        public static bool IsOwnerOfKind(this V1Pod pod, params string[] kinds) =>
+           pod.Metadata?.OwnerReferences?.Any(r => kinds.Any(k => StringComparer.OrdinalIgnoreCase.Equals(r.Kind, k))) ?? false;
     }
 }

--- a/src/library/Utilities/RemoteContainerConnectionDetailsResolver.cs
+++ b/src/library/Utilities/RemoteContainerConnectionDetailsResolver.cs
@@ -210,25 +210,29 @@ namespace Microsoft.BridgeToKubernetes.Library.Utilities
             CancellationToken cancellationToken)
         {
             (var owningSetName, var owningObjectType) = GetOwningSetFromPods(pods, remoteContainerConnectionDetails.ServiceName);
-            _log.Verbose($"Owning object type: {owningObjectType}");
+            _log.Info($"Owning object type: {owningObjectType}");
             if (string.Equals(owningObjectType, "ReplicaSet"))
             {
+                _log.Info("Inside if condition for replicaset");
                 // There is a single common replicaSet owning all the pods. Time to make sure there is a deployment owning it
                 var replicaSet = await _kubernetesClient.GetV1ReplicaSetAsync(remoteContainerConnectionDetails.NamespaceName, owningSetName, cancellationToken: cancellationToken);
                 if (replicaSet == null || replicaSet.Metadata?.OwnerReferences == null)
                 {
                     // replicaSet not found or no deployment owning it
+                    _log.Info("replicaset is null:"+ replicaSet);
                     throw new InvalidOperationException(string.Format(Resources.FailedToResolveResourceBackingServiceFormat, "ReplicaSet", remoteContainerConnectionDetails.ServiceName));
                 }
 
                 var deployments = replicaSet.Metadata.OwnerReferences.Where(r => StringComparer.OrdinalIgnoreCase.Equals(r.Kind, "Deployment")).Select(d => d.Name);
                 if (deployments.Count() != 1)
                 {
+                    _log.Info("deployments is not one:" + deployments.Count());
                     throw new InvalidOperationException(string.Format(Resources.FailedToResolveResourceBackingServiceFormat, "Deployment", remoteContainerConnectionDetails.ServiceName));
                 }
                 var deployment = await _kubernetesClient.GetV1DeploymentAsync(remoteContainerConnectionDetails.NamespaceName, deployments.First(), cancellationToken);
                 if (deployment == null)
                 {
+                    _log.Info("deployment is not found:" + deployment);
                     throw new InvalidOperationException(string.Format(Resources.FailedToResolveResourceBackingServiceFormat, "Deployment", remoteContainerConnectionDetails.ServiceName));
                 }
                 _log.Verbose($"Resolved backing deployment: {new PII(deployment.Name())}");
@@ -307,6 +311,7 @@ namespace Microsoft.BridgeToKubernetes.Library.Utilities
 
         private (string owningSetName, string owningSetType) GetOwningSetFromPods(IEnumerable<V1Pod> pods, string serviceName)
         {
+            _log.Info("Inside GetOwningSetFromPods");
             if (pods == null || !pods.Any())
             {
                 throw new InvalidOperationException("Failed to determine the resource backing the service");
@@ -318,6 +323,7 @@ namespace Microsoft.BridgeToKubernetes.Library.Utilities
             var owningSets = pods.First().Metadata?.OwnerReferences?.Where(r => StringComparer.OrdinalIgnoreCase.Equals(r.Kind, "ReplicaSet")).Select(r => r.Name);
             if (owningSets != null && owningSets.Any())
             {
+                _log.Info("OwningSets name:" + owningSets);
                 resourceType = "ReplicaSet";
             }
             else
@@ -328,27 +334,34 @@ namespace Microsoft.BridgeToKubernetes.Library.Utilities
                 {
                     throw new UserVisibleException(_operationContext, Resources.ResourceNotSupportedFormat, Product.Name);
                 }
+                _log.Info("OwningSets name:" + owningSets);
                 resourceType = "StatefulSet";
             }
 
             foreach (var pod in pods)
             {
+                _log.Info("Inside pod for loop and resourceType is:"+resourceType);
                 // For each pod, intersect the initial result with the set owning the current pod
                 var podReplicaSets = pod.Metadata?.OwnerReferences?.Where(r => StringComparer.OrdinalIgnoreCase.Equals(r.Kind, resourceType)).Select(r => r.Name);
+                _log.Info("podReplicaSets:" + podReplicaSets);
                 if (podReplicaSets == null || !podReplicaSets.Any())
                 {
+                    _log.Info("podReplicaSets is null/empty:" + podReplicaSets);
                     throw new InvalidOperationException(string.Format(Resources.FailedToResolveResourceBackingServiceFormat, resourceType, serviceName));
                 }
                 owningSets = owningSets.Intersect(podReplicaSets, StringComparer.OrdinalIgnoreCase);
+                _log.Info("owningSets after intersection:" + owningSets);
 
                 // If at any time the intersection is 0, it means that there is no single resource is owning all the pods
                 if (owningSets.Count() == 0)
                 {
+                    _log.Info("OwningSets count is zero" + owningSets.Count());
                     throw new UserVisibleException(_operationContext, Resources.SpecifiedServiceBackedByManyPodsInDifferentResourcesFormat, serviceName, pods.Count(), $"{resourceType}s");
                 }
             }
             if (owningSets.Count() != 1)
             {
+                _log.Info("OwningSets count is not one" + owningSets.Count());
                 throw new InvalidOperationException(string.Format(Resources.FailedToResolveResourceBackingServiceFormat, resourceType, serviceName));
             }
 

--- a/src/library/Utilities/RemoteContainerConnectionDetailsResolver.cs
+++ b/src/library/Utilities/RemoteContainerConnectionDetailsResolver.cs
@@ -298,7 +298,7 @@ namespace Microsoft.BridgeToKubernetes.Library.Utilities
                     podsNotRunningDevHostAgent = podsNotRunningDevHostAgent.Where(p => p.IsOwnerOfKind("ReplicaSet", "StatefulSet"));
                     if (podsNotRunningDevHostAgent.Count() == 0)
                     {
-                        _log.Warning("{0} pods found, after filtering pods which are of kind replicaset or statefulset", pods.Count);
+                        _log.Warning("{0} pods found of kind replicaset or statefulset", pods.Count);
                         throw new UserVisibleException(_operationContext, Resources.SpecifiedServiceNotBackedByRunningPodFormat, service.Metadata?.Name, $"kubectl get pods --namespace {namespaceName}");
                     }
 

--- a/src/library/Utilities/RemoteContainerConnectionDetailsResolver.cs
+++ b/src/library/Utilities/RemoteContainerConnectionDetailsResolver.cs
@@ -210,7 +210,7 @@ namespace Microsoft.BridgeToKubernetes.Library.Utilities
             CancellationToken cancellationToken)
         {
             (var owningSetName, var owningObjectType) = GetOwningSetFromPods(pods, remoteContainerConnectionDetails.ServiceName);
-            _log.Info($"Owning object type: {owningObjectType}");
+            _log.Verbose($"Owning object type: {owningObjectType}");
             if (string.Equals(owningObjectType, "ReplicaSet"))
             {
                 _log.Info("Inside if condition for replicaset");
@@ -299,7 +299,7 @@ namespace Microsoft.BridgeToKubernetes.Library.Utilities
                     }
 
                     // filter pods which are not replicaset or statefulset
-                    podsNotRunningDevHostAgent = podsNotRunningDevHostAgent.Where(p => p.Metadata?.OwnerReferences?.Any(r => StringComparer.OrdinalIgnoreCase.Equals(r.Kind, "ReplicaSet") || StringComparer.OrdinalIgnoreCase.Equals(r.Kind, "StatefulSet")) ?? false);
+                    podsNotRunningDevHostAgent = podsNotRunningDevHostAgent = podsNotRunningDevHostAgent.Where(p => p.IsOwnerOfKind("ReplicaSet", "StatefulSet"));
                     if (podsNotRunningDevHostAgent.Count() == 0)
                     {
                         _log.Warning("{0} pods found, after filtering pods which are of kind replicaset or statefulset", pods.Count);


### PR DESCRIPTION
This PR is to fix #267. 
Root cause was if a user cluster contains multiple pods with same/similar name but different kind like pod-a is replicaset and pod-a-job is job, code is failing to recognize this and throws errors. 