### PR TITLE
Skip endpoint without ports in LocalEnvironmentManager

### DIFF
--- a/src/library.tests/LocalEnvironmentManagerTests.cs
+++ b/src/library.tests/LocalEnvironmentManagerTests.cs
@@ -9,6 +9,7 @@ using Microsoft.BridgeToKubernetes.Common.Models.Settings;
 using Microsoft.BridgeToKubernetes.Library.Connect;
 using Microsoft.BridgeToKubernetes.Library.Models;
 using Microsoft.BridgeToKubernetes.TestHelpers;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Xunit;
@@ -268,6 +269,21 @@ namespace Microsoft.BridgeToKubernetes.Library.Tests
                     ["PODNAME_SERVICENAME_SERVICE_PORT_CLIENT"] = "5051",
                     
                 }
+            };
+
+            // endpoints with no port should not throw
+            yield return new object[]
+            {
+                new[]
+                {
+                    new EndpointInfo
+                    {
+                        DnsName = "noport.servicename",
+                        LocalIP = System.Net.IPAddress.Parse("127.0.0.1"),
+                        Ports = Array.Empty<PortPair>()
+                    }
+                },
+                new Dictionary<string, string>()
             };
         }
 

--- a/src/library/Connect/LocalEnvironmentManager.cs
+++ b/src/library/Connect/LocalEnvironmentManager.cs
@@ -426,7 +426,7 @@ namespace Microsoft.BridgeToKubernetes.Library.Connect
 
             foreach (var endpoint in workloadInfo.ReachableEndpoints)
             {
-                if (endpoint.Ports.Length == 0)
+                if (endpoint.Ports == null || endpoint.Ports.Length == 0)
                 {
                     _log.Verbose("Skipping endpoint {0} as it has no configured port", endpoint.DnsName);
                     continue;

--- a/src/library/Connect/LocalEnvironmentManager.cs
+++ b/src/library/Connect/LocalEnvironmentManager.cs
@@ -426,6 +426,12 @@ namespace Microsoft.BridgeToKubernetes.Library.Connect
 
             foreach (var endpoint in workloadInfo.ReachableEndpoints)
             {
+                if (endpoint.Ports.Length == 0)
+                {
+                    _log.Verbose("Skipping endpoint {0} as it has no configured port", endpoint.DnsName);
+                    continue;
+                }
+
                 if (string.Equals(endpoint.DnsName, DAPR, StringComparison.OrdinalIgnoreCase))
                 {
                     // Override the DAPR env variables with the real local ports (that might be different if we neeeded to re-allocate them)


### PR DESCRIPTION
Fix https://github.com/Azure/Bridge-To-Kubernetes/issues/234

This PR fixes Index out of bound when user's namespace contains UDP services without ports. 