### PR TITLE
change to 1es pool

### DIFF
--- a/.github/workflows/acr-build-publish.yml
+++ b/.github/workflows/acr-build-publish.yml
@@ -25,7 +25,8 @@ jobs:
             imageName: lpkrestorationjob
           - components: routingmanager
             imageName: routingmanager
-    runs-on: ubuntu-latest
+    runs-on: 
+      labels: ["self-hosted", "1ES.Pool=${{ vars.RUNNER_BASE_NAME }}-ubuntu"]
     environment: ${{ github.event.inputs.environment }}
     steps:
       - name: Harden Runner
@@ -37,12 +38,10 @@ jobs:
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@f95db51fddba0c2d1ec667646a06c2ce06100226 # v3.0.0
-      - name: Login to Docker Hub
-        uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d # v3.0.0
-        with:
-          registry: ${{ vars.ACR_REGISTRY }}
-          username: ${{ secrets.ACR_USERNAME }}
-          password: ${{ secrets.ACR_PASSWORD }}
+      - name: Authenticate to ACR
+        run : |
+          az login --identity
+          az acr login -n ${{ vars.AZURE_REGISTRY_SERVER }}
       - name: Set telemetry variables
         shell: bash
         run: |


### PR DESCRIPTION
This PR updates publishing to ACR with new 1es pool eliminating the need for ACR_USERNAME and ACR_PASSWORD. Once this workflow is sucessfully, those secrets can be deleted.