### PR TITLE
update 1es pool names

### DIFF
--- a/.github/workflows/acr-build-publish.yml
+++ b/.github/workflows/acr-build-publish.yml
@@ -26,7 +26,7 @@ jobs:
           - components: routingmanager
             imageName: routingmanager
     runs-on: 
-      labels: ["self-hosted", "1ES.Pool=${{ vars.RUNNER_BASE_NAME }}-ubuntu"]
+      labels: ["self-hosted", "1ES.Pool=1es-b2k-pool-ubuntu"]
     environment: ${{ github.event.inputs.environment }}
     steps:
       - name: Harden Runner

--- a/.github/workflows/acr-build-publish.yml
+++ b/.github/workflows/acr-build-publish.yml
@@ -27,7 +27,7 @@ jobs:
             imageName: routingmanager
     environment: ${{ github.event.inputs.environment }}
     runs-on: 
-      labels: ["self-hosted", "${{ vars.AZURE_1ES_POOL_NAME }}"]
+      labels: ["self-hosted", "1ES.Pool=${{ vars.RUNNER_BASE_NAME }}-${{ github.event.inputs.environment }}-ubuntu"]
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@63c24ba6bd7ba022e95695ff85de572c04a18142 # v2.7.0

--- a/.github/workflows/acr-build-publish.yml
+++ b/.github/workflows/acr-build-publish.yml
@@ -11,6 +11,8 @@ on:
           - development
           - staging
           - prod
+env:
+  runner_base: ${{ vars.RUNNER_BASE_NAME }}
 permissions:
   contents: read
 
@@ -25,9 +27,9 @@ jobs:
             imageName: lpkrestorationjob
           - components: routingmanager
             imageName: routingmanager
-    environment: ${{ github.event.inputs.environment }}
     runs-on: 
-      labels: ["self-hosted", "1ES.Pool=${{ vars.RUNNER_BASE_NAME }}-ubuntu"]
+      labels: ["self-hosted", "1ES.Pool=$runner_base-ubuntu"]
+    environment: ${{ github.event.inputs.environment }}
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@63c24ba6bd7ba022e95695ff85de572c04a18142 # v2.7.0

--- a/.github/workflows/acr-build-publish.yml
+++ b/.github/workflows/acr-build-publish.yml
@@ -27,7 +27,7 @@ jobs:
             imageName: routingmanager
     environment: ${{ github.event.inputs.environment }}
     runs-on: 
-      labels: ["self-hosted", "1ES.Pool=\"${{ vars.RUNNER_BASE_NAME }}\"-ubuntu"]
+      labels: ["self-hosted", "${{ vars.AZURE_1ES_POOL_NAME }}"]
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@63c24ba6bd7ba022e95695ff85de572c04a18142 # v2.7.0

--- a/.github/workflows/acr-build-publish.yml
+++ b/.github/workflows/acr-build-publish.yml
@@ -25,9 +25,9 @@ jobs:
             imageName: lpkrestorationjob
           - components: routingmanager
             imageName: routingmanager
-    runs-on: 
-      labels: ["self-hosted", "1ES.Pool=1es-b2k-pool-ubuntu"]
     environment: ${{ github.event.inputs.environment }}
+    runs-on: 
+      labels: ["self-hosted", "1ES.Pool=${{ vars.RUNNER_BASE_NAME }}-ubuntu"]
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@63c24ba6bd7ba022e95695ff85de572c04a18142 # v2.7.0
@@ -70,4 +70,4 @@ jobs:
           file: src/${{ matrix.components }}/Dockerfile
           platforms: linux/arm64,linux/amd64
           push: true
-          tags: ${{ vars.ACR_REGISTRY }}/${{ matrix.imageName }}:${{ env.tag }}
+          tags: ${{ vars.AZURE_REGISTRY_SERVER }}/${{ matrix.imageName }}:${{ env.tag }}

--- a/.github/workflows/acr-build-publish.yml
+++ b/.github/workflows/acr-build-publish.yml
@@ -11,8 +11,6 @@ on:
           - development
           - staging
           - prod
-env:
-  runner_base: ${{ vars.RUNNER_BASE_NAME }}
 permissions:
   contents: read
 
@@ -27,9 +25,9 @@ jobs:
             imageName: lpkrestorationjob
           - components: routingmanager
             imageName: routingmanager
-    runs-on: 
-      labels: ["self-hosted", "1ES.Pool=$runner_base-ubuntu"]
     environment: ${{ github.event.inputs.environment }}
+    runs-on: 
+      labels: ["self-hosted", "1ES.Pool=\"${{ vars.RUNNER_BASE_NAME }}\"-ubuntu"]
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@63c24ba6bd7ba022e95695ff85de572c04a18142 # v2.7.0


### PR DESCRIPTION
This branch PR fixes the acr build and push using different 1es pools for development vs prod registries for b2k. 

example run for staging - https://github.com/Azure/Bridge-To-Kubernetes/actions/runs/8088192134
development - https://github.com/Azure/Bridge-To-Kubernetes/actions/runs/8088254811
prod - https://github.com/Azure/Bridge-To-Kubernetes/actions/runs/8072443965/job/22054200309