### PR TITLE
revert back to dotnet 7.0

### DIFF
--- a/src/devhostagent.restorationjob/Dockerfile
+++ b/src/devhostagent.restorationjob/Dockerfile
@@ -1,5 +1,5 @@
 # Build container
-FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:8.0-cbl-mariner2.0@sha256:e14034d5ba09b02204d56e809343586475433fd021938488088ccc5cae9d3cd2 AS build
+FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:7.0-cbl-mariner2.0@sha256:69e18e87d68a6653550c1eed320cdddc3ff39296bb9d04f3317eca6e500daea9 AS build
 ARG TARGETARCH
 ARG Configuration=Release
 ARG TelemetryType=TELEMETRY_DEVELOPMENT
@@ -18,7 +18,7 @@ ENV MINDARO_BUILD_NUMBER=${MindaroBuildNumber}
 RUN dotnet publish -c ${Configuration} -a ${TARGETARCH} --self-contained false --no-restore -o /output devhostAgent.restorationjob.csproj
 
 # Final container
-FROM mcr.microsoft.com/dotnet/aspnet:8.0-cbl-mariner2.0@sha256:11d43dfc1c0887670f1580e1ac03f100dc8418845e5530e66aa266915a260abb as final
+FROM mcr.microsoft.com/dotnet/aspnet:7.0-cbl-mariner2.0@sha256:fccd19c673dff30603e1f2ca3ae05234e0c1a2512a30e9b71debaf34a1215664 as final
 
 # Setup common tools
 RUN tdnf clean all && \

--- a/src/devhostagent/Dockerfile
+++ b/src/devhostagent/Dockerfile
@@ -1,5 +1,5 @@
 # Build container
-FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:8.0-cbl-mariner2.0@sha256:e14034d5ba09b02204d56e809343586475433fd021938488088ccc5cae9d3cd2 AS build
+FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:sdk:7.0-cbl-mariner2.0@sha256:69e18e87d68a6653550c1eed320cdddc3ff39296bb9d04f3317eca6e500daea9 AS build
 
 ARG TARGETARCH
 ARG Configuration=Release
@@ -19,7 +19,7 @@ ENV MINDARO_BUILD_NUMBER=${MindaroBuildNumber}
 RUN dotnet publish -c ${Configuration} -a ${TARGETARCH} --self-contained false --no-restore -o /src/publish devhostAgent.csproj
 
 # Final container
-FROM mcr.microsoft.com/dotnet/aspnet:8.0-cbl-mariner2.0@sha256:11d43dfc1c0887670f1580e1ac03f100dc8418845e5530e66aa266915a260abb as final
+FROM mcr.microsoft.com/dotnet/aspnet:aspnet:7.0-cbl-mariner2.0@sha256:fccd19c673dff30603e1f2ca3ae05234e0c1a2512a30e9b71debaf34a1215664 as final
 
 RUN tdnf clean all && \
  tdnf check-update && \

--- a/src/routingmanager/Dockerfile
+++ b/src/routingmanager/Dockerfile
@@ -1,5 +1,5 @@
 # Build container
-FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:8.0-cbl-mariner2.0@sha256:e14034d5ba09b02204d56e809343586475433fd021938488088ccc5cae9d3cd2 AS build
+FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:7.0-cbl-mariner2.0@sha256:69e18e87d68a6653550c1eed320cdddc3ff39296bb9d04f3317eca6e500daea9 AS build
 ARG TARGETARCH
 ARG Configuration=Release
 ARG TelemetryType=TELEMETRY_DEVELOPMENT
@@ -19,7 +19,7 @@ ENV MINDARO_BUILD_NUMBER=${MindaroBuildNumber}
 RUN dotnet publish -c ${Configuration} -a ${TARGETARCH} --self-contained false --no-restore -o /src/publish
 
 # Final container
-FROM mcr.microsoft.com/dotnet/aspnet:8.0-cbl-mariner2.0@sha256:11d43dfc1c0887670f1580e1ac03f100dc8418845e5530e66aa266915a260abb as final
+FROM mcr.microsoft.com/dotnet/aspnet:7.0-cbl-mariner2.0@sha256:fccd19c673dff30603e1f2ca3ae05234e0c1a2512a30e9b71debaf34a1215664 as final
 ARG TARGETARCH
 ARG KUBECTL_VERSION=v1.27.3
 ARG INSTALL_LOCATION=/app/kubectl/linux


### PR DESCRIPTION
This PR is to revert dependent bot update to dotnet 8.0 for dockerfiles for devhostagent, restorationjob and routing manager which is blocking manual testing and release to production. Later once it is upgraded to dotnet 8.0, then these files will be updated. 